### PR TITLE
Add dark mode

### DIFF
--- a/src/components/AppBar.svelte
+++ b/src/components/AppBar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 	import House from '@lucide/svelte/icons/house';
+	import ThemeToggle from './ThemeToggle.svelte';
 
 	// The shared 44px top bar: a bordered home-icon cell on the left, then whatever
 	// the caller renders (IDE tabs + cog, or a settings title). Keeps the two bars
@@ -11,6 +12,8 @@
 <header class="bar">
 	<a class="home" href="/" title="All instances" aria-label="All instances"><House size={18} /></a>
 	{@render children?.()}
+	<div class="spacer"></div>
+	<div class="theme-cell"><ThemeToggle /></div>
 </header>
 
 <style>
@@ -34,5 +37,14 @@
 	.home:hover {
 		background: var(--ink);
 		color: var(--bg);
+	}
+	.spacer {
+		flex: 1;
+	}
+	.theme-cell {
+		display: flex;
+		align-items: center;
+		padding: 0 10px;
+		border-left: 1px solid var(--rule);
 	}
 </style>

--- a/src/components/SettingsView.svelte
+++ b/src/components/SettingsView.svelte
@@ -705,7 +705,7 @@
 			background 0.15s ease;
 	}
 	.switch input:checked + .track {
-		background: rgba(34, 197, 94, 0.32);
+		background: var(--switch-on-bg);
 	}
 	.switch input:checked + .track .thumb {
 		transform: translateX(20px);

--- a/src/components/ThemeToggle.svelte
+++ b/src/components/ThemeToggle.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import Sun from '@lucide/svelte/icons/sun';
+	import Moon from '@lucide/svelte/icons/moon';
+	import { getTheme, setTheme, type Theme } from '../theme.ts';
+
+	// svelte-ignore state_referenced_locally
+	let theme: Theme = $state(getTheme());
+
+	function toggle() {
+		theme = theme === 'dark' ? 'light' : 'dark';
+		setTheme(theme);
+		document.documentElement.dataset.theme = theme === 'dark' ? 'dark' : '';
+	}
+</script>
+
+<button
+	type="button"
+	class="toggle"
+	onclick={toggle}
+	aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+	title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+>
+	{#if theme === 'dark'}
+		<Sun size={16} />
+	{:else}
+		<Moon size={16} />
+	{/if}
+</button>
+
+<style>
+	.toggle {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		border: 1px solid var(--ink);
+		background: var(--bg-card);
+		color: var(--ink);
+	}
+	.toggle:hover {
+		background: var(--ink);
+		color: var(--bg);
+	}
+</style>

--- a/src/components/TopBar.svelte
+++ b/src/components/TopBar.svelte
@@ -5,6 +5,7 @@
 	import type { AuthProvider } from '../types.ts';
 	import Brand from './Brand.svelte';
 	import SettingsCog from './SettingsCog.svelte';
+	import ThemeToggle from './ThemeToggle.svelte';
 	import CredMenu from './CredMenu.svelte';
 	import Button from './Button.svelte';
 
@@ -34,6 +35,7 @@
 		{#if isDev}
 			<Button variant="default" size="sm" icon={Component} href="/debug">Debug</Button>
 		{/if}
+		<ThemeToggle />
 		<SettingsCog />
 		<CredMenu {auth} />
 		<Button variant="danger" size="sm" onclick={onDeleteAll} disabled={!canDelete}>

--- a/src/components/UiShowcase.svelte
+++ b/src/components/UiShowcase.svelte
@@ -21,8 +21,10 @@
 
 	// --- Design tokens (mirrors :root in src/shell.html) ---
 	// `token` drives the swatch fill via var(--token) so it auto-syncs with the
-	// real value; `hex` is a text label only. `border` flags pale chips that need
-	// an outline to read against the panel.
+	// real value (including the dark-theme override — toggle it with the theme
+	// button in the top bar); `hex` is a text label only and reflects the
+	// light-theme value regardless of the active theme. `border` flags pale
+	// chips that need an outline to read against the panel.
 	const palette: { group: string; swatches: { token: string; hex: string; border?: boolean }[] }[] =
 		[
 			{

--- a/src/index.isolated.test.ts
+++ b/src/index.isolated.test.ts
@@ -3,11 +3,15 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import path from 'node:path';
 import type { Server } from 'bun';
 import { Mochi } from 'mochi-framework';
+import { themeHandle } from './lib/theme.server.ts';
 
 const routes = {
 	'/': Mochi.page('./src/__fixtures__/HelloWorld.svelte')
 };
 
+// Mochi.serve() is a process-wide singleton (see mochiConfig.ts), so every
+// isolated test that needs a live server shares this one instance — including
+// the themeHandle checks below, which is why `handle` is wired in here.
 describe('minimal app', () => {
 	let server: Server<undefined>;
 	let outDir: string;
@@ -21,6 +25,7 @@ describe('minimal app', () => {
 			logger: { enabled: false },
 			outDir,
 			htmlShell: './src/shell.html',
+			handle: themeHandle,
 			routes
 		});
 		base = `http://localhost:${server.port}`;
@@ -35,5 +40,15 @@ describe('minimal app', () => {
 		const res = await fetch(base);
 		expect(res.status).toBe(200);
 		expect(await res.text()).toContain('Hello Mochi!');
+	});
+
+	test('GET / renders light theme (no data-theme attribute) with no theme cookie', async () => {
+		const res = await fetch(base);
+		expect(await res.text()).not.toContain('<html data-theme');
+	});
+
+	test('GET / renders data-theme="dark" when the theme cookie is dark', async () => {
+		const res = await fetch(base, { headers: { Cookie: 'theme=dark' } });
+		expect(await res.text()).toContain('<html data-theme="dark"');
 	});
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
-import { Mochi, silenceInternalRoutes } from 'mochi-framework';
+import { Mochi, sequence, silenceInternalRoutes } from 'mochi-framework';
 import { routes } from './routes.ts';
 import { basicAuth } from './lib/auth.server.ts';
+import { themeHandle } from './lib/theme.server.ts';
 import { PROXY_PREFIX } from './lib/proxy.server.ts';
 import {
 	BASIC_AUTH_PASSWORD,
@@ -27,8 +28,9 @@ await Mochi.serve({
 	// Trailing-slash normalization is disabled entirely: the proxy's `/p/:id`
 	// route does its own bare-`/p/<id>` → `/p/<id>/` redirect (code-server needs
 	// the slash), and we don't want Mochi's global policy touching proxy paths.
-	// Gate the whole app (UI, APIs, proxy) behind one Basic Auth password.
-	handle: basicAuth,
+	// Gate the whole app (UI, APIs, proxy) behind one Basic Auth password, then
+	// stamp the visitor's theme cookie onto the SSR'd <html> tag.
+	handle: sequence(basicAuth, themeHandle),
 	// The app is served same-origin (no reverse proxy by default). Pin the public
 	// origin so Mochi's CSRF origin check accepts our own form POSTs in production
 	// mode — without this it refuses every form mutation and warns about a missing

--- a/src/lib/theme.isolated.test.ts
+++ b/src/lib/theme.isolated.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test';
+import { injectThemeAttribute } from './theme.server.ts';
+
+// The end-to-end cookie -> SSR data-theme behavior (themeHandle wired into a
+// live Mochi server) is covered in src/index.isolated.test.ts instead of here:
+// Mochi.serve() is a process-wide singleton, so only one test file can spin
+// up a server for the whole test run.
+describe('injectThemeAttribute', () => {
+	test('injects data-theme="dark" when the cookie says dark', () => {
+		expect(injectThemeAttribute('<html lang="en">', 'dark')).toBe(
+			'<html data-theme="dark" lang="en">'
+		);
+	});
+
+	test('leaves the HTML untouched when the cookie is absent', () => {
+		expect(injectThemeAttribute('<html lang="en">', undefined)).toBe('<html lang="en">');
+	});
+
+	test('leaves the HTML untouched for any non-"dark" cookie value', () => {
+		expect(injectThemeAttribute('<html lang="en">', 'light')).toBe('<html lang="en">');
+		expect(injectThemeAttribute('<html lang="en">', 'bogus')).toBe('<html lang="en">');
+	});
+});

--- a/src/lib/theme.server.ts
+++ b/src/lib/theme.server.ts
@@ -15,6 +15,17 @@ export function injectThemeAttribute(html: string, cookieValue: string | undefin
  */
 export const themeHandle: Handle = ({ event, resolve }) =>
 	resolve(event, {
-		transformPage: ({ html }) =>
-			injectThemeAttribute(html, getRequestContext().cookies.get('theme'))
+		transformPage: ({ html }) => {
+			// transformPage also fires for HTML responses (e.g. 404s) produced by
+			// Mochi's fetch-fallback path (static assets, proxy passthrough), which
+			// runs outside the page/api dispatchers' requestContext.run() — so no
+			// request context, and thus no theme cookie, is available there.
+			let cookieValue: string | undefined;
+			try {
+				cookieValue = getRequestContext().cookies.get('theme');
+			} catch {
+				return html;
+			}
+			return injectThemeAttribute(html, cookieValue);
+		}
 	});

--- a/src/lib/theme.server.ts
+++ b/src/lib/theme.server.ts
@@ -1,0 +1,20 @@
+import { getRequestContext, type Handle } from 'mochi-framework';
+
+/** Injects `data-theme="dark"` into the shell's `<html>` tag when the theme cookie says so. Light is the implicit default — an absent/unrecognized cookie leaves the HTML untouched. */
+export function injectThemeAttribute(html: string, cookieValue: string | undefined): string {
+	if (cookieValue !== 'dark') return html;
+	return html.replace('<html', '<html data-theme="dark"');
+}
+
+/**
+ * Rewrites the SSR'd `<html>` tag to carry the visitor's theme cookie before the
+ * response is sent, so the first paint already renders in the right theme — no
+ * client-side flash-of-wrong-theme on reload. Composed alongside `basicAuth` via
+ * `sequence()` in src/index.ts rather than folded into it, to keep auth/CSRF
+ * logic untouched.
+ */
+export const themeHandle: Handle = ({ event, resolve }) =>
+	resolve(event, {
+		transformPage: ({ html }) =>
+			injectThemeAttribute(html, getRequestContext().cookies.get('theme'))
+	});

--- a/src/shell.html
+++ b/src/shell.html
@@ -27,11 +27,32 @@
 				--attn-done: #22c55e;
 				--attn-waiting: #f59e0b;
 				--info: #388bfd;
+				--grid-line: rgba(0, 0, 0, 0.035);
+				/* --attn-done at reduced opacity — reads correctly on both themes' track color. */
+				--switch-on-bg: rgba(34, 197, 94, 0.32);
 				--font-display: 'Doto Variable', 'JetBrains Mono Variable', monospace;
 				--font-mono:
 					'JetBrains Mono Variable', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 				--font-serif: var(--font-display);
 				--font-sans: var(--font-mono);
+			}
+			:root[data-theme='dark'] {
+				--bg: #1b1c15;
+				--bg-card: #24261c;
+				--ink: #e8e9df;
+				--ink-soft: #b7b8a9;
+				--ink-faint: #85867a;
+				--rule: #46473a;
+				--rule-soft: #34352a;
+				--warn-bg: #4a3d12;
+				--warn-line: #c9a83a;
+				--warn-ink: #f3e3a0;
+				--ok-bg: #23421a;
+				--ok-line: #6fa84a;
+				--ok-ink: #cdeab8;
+				--danger: #e2564a;
+				--danger-soft: #4a231e;
+				--grid-line: rgba(255, 255, 255, 0.035);
 			}
 			* {
 				box-sizing: border-box;
@@ -69,9 +90,8 @@
 				font-family: var(--font-sans);
 				/* Pale LCD panel with a faint pixel-grid matrix overlay. */
 				background:
-					repeating-linear-gradient(0deg, rgba(0, 0, 0, 0.035) 0 1px, transparent 1px 3px),
-					repeating-linear-gradient(90deg, rgba(0, 0, 0, 0.035) 0 1px, transparent 1px 3px),
-					var(--bg);
+					repeating-linear-gradient(0deg, var(--grid-line) 0 1px, transparent 1px 3px),
+					repeating-linear-gradient(90deg, var(--grid-line) 0 1px, transparent 1px 3px), var(--bg);
 				color: var(--ink);
 				font-size: 14px;
 				line-height: 1.55;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,20 @@
+/**
+ * Cookie-backed dark/light theme preference. IMPORTANT: only import this from
+ * `.svelte` files (or plain `.ts` modules they import) — `cookies` here resolves
+ * through Mochi's isomorphic virtual module, which only exists in the Svelte
+ * build graph. Server entry files (index.ts, *.server.ts) must instead use
+ * `getRequestContext().cookies` — see src/lib/theme.server.ts.
+ */
+import { cookies } from 'mochi-framework';
+
+export type Theme = 'light' | 'dark';
+
+const THEME_KEY = 'theme';
+
+export function getTheme(): Theme {
+	return cookies.get(THEME_KEY) === 'dark' ? 'dark' : 'light';
+}
+
+export function setTheme(theme: Theme): void {
+	cookies.set(THEME_KEY, theme, { expires: 400, path: '/' });
+}


### PR DESCRIPTION
## Summary
- Cookie-backed dark/light theme toggle, mounted in the top bar (Dashboard) and app bar (Settings/IDE)
- SSR-correct: a `transformPage` handle stamps `data-theme="dark"` onto `<html>` server-side based on the theme cookie before the response is sent, so there's no flash of the wrong theme on load/reload
- Dark palette added as a `:root[data-theme='dark']` token override in `src/shell.html`; light stays the untouched default
- Two small new tokens (`--grid-line`, `--switch-on-bg`) fix spots that hardcoded colors and would otherwise have broken in dark mode

## Test plan
- [x] `bun run checks` (format + typecheck + tests) passes
- [x] Manually verified via SSR snapshot screenshots that Dashboard, Settings, and the `/debug` UI showcase all re-theme correctly with the `theme=dark` cookie, with no flash on reload
- [ ] Reviewer: toggle dark mode from both the Dashboard and Settings pages in a live browser and confirm they stay in sync