### PR TITLE
Enable terminal copy/paste in code-server

### DIFF
--- a/src/components/ThemeToggle.svelte
+++ b/src/components/ThemeToggle.svelte
@@ -3,7 +3,6 @@
 	import Moon from '@lucide/svelte/icons/moon';
 	import { getTheme, setTheme, type Theme } from '../theme.ts';
 
-	// svelte-ignore state_referenced_locally
 	let theme: Theme = $state(getTheme());
 
 	function toggle() {

--- a/src/lib/devcontainer.server.ts
+++ b/src/lib/devcontainer.server.ts
@@ -53,7 +53,11 @@ const CODE_SERVER_SETTINGS = {
 	// tasks are gated behind trust, and the bare default image isn't trusted by default.
 	'security.workspace.trust.enabled': false,
 	'security.workspace.trust.startupPrompt': 'never',
-	'security.workspace.trust.banner': 'never'
+	'security.workspace.trust.banner': 'never',
+	// Selecting terminal text copies it, and right-click pastes — Ctrl+Shift+V is
+	// intercepted by the browser for devtools, so this is the usable clipboard path.
+	'terminal.integrated.copyOnSelection': true,
+	'terminal.integrated.rightClickBehavior': 'paste'
 };
 
 /**


### PR DESCRIPTION
## Summary
- Adds `terminal.integrated.copyOnSelection: true` and `terminal.integrated.rightClickBehavior: "paste"` to the code-server settings template so terminal copy/paste works properly in the browser (Ctrl+Shift+V is intercepted by the browser for devtools).
- Also fixes a stale `svelte-ignore` comment in `ThemeToggle.svelte` that's been failing CI's lint step on `main` since the dark-mode merge (unrelated to the terminal fix, but needed for CI to go green on this PR).

## Test plan
- [x] `bun run checks` (format, typecheck, tests) passes
- [x] Confirmed a booted instance's injected `~/.local/share/code-server/User/settings.json` (well, its pre-copy staging file, `.devcontainer/code-server-settings.json`) contains both new keys
- [ ] Not yet done: actual browser verification that selecting terminal text copies it and right-click pastes — a local attempt to boot a test container hit an unrelated environment issue (port collision with an already-running instance) before reaching that step