### PR TITLE
Allow renaming an instance from the IDE tab bar

### DIFF
--- a/src/components/AppShell.svelte
+++ b/src/components/AppShell.svelte
@@ -35,6 +35,37 @@
 		Object.fromEntries(snapshot.map((i) => [i.id, i.attention]))
 	);
 
+	// Inline rename for the IDE tab bar — same pattern as DashboardView/InstanceCard.
+	let editingId = $state<string | null>(null);
+	let editingName = $state('');
+
+	function startRename(instance: Instance) {
+		editingId = instance.id;
+		editingName = instance.name;
+	}
+
+	function cancelRename() {
+		editingId = null;
+		editingName = '';
+	}
+
+	async function commitRename(id: string) {
+		const name = editingName.trim();
+		const original = instances.find((i) => i.id === id)?.name;
+		// Nothing to do on an empty or unchanged name — just close the editor.
+		if (!name || name === original) {
+			cancelRename();
+			return;
+		}
+		cancelRename();
+		try {
+			await apiPost(`/api/instances/${id}/rename`, { name }, 'Failed to rename');
+			// The SSE stream reflects the new name.
+		} catch (err) {
+			console.error('Failed to rename', err);
+		}
+	}
+
 	// --- Client-side router (Dashboard ⇄ IDE only) --------------------------------
 	// Mochi has no client router; we keep a reactive path and intercept the handful
 	// of in-app links so navigating between `/` and `/ide/:id` never reloads the
@@ -185,7 +216,17 @@
 
 <div class="app" class:ide={onIde}>
 	{#if onIde}
-		<IdeBar {running} {active} {attention} onselect={(id) => navigate(`/ide/${id}`)} />
+		<IdeBar
+			{running}
+			{active}
+			{attention}
+			{editingId}
+			bind:editingName
+			onselect={(id) => navigate(`/ide/${id}`)}
+			onstartrename={startRename}
+			oncommitrename={commitRename}
+			oncancelrename={cancelRename}
+		/>
 	{:else}
 		<DashboardView preflight={livePreflight} {instances} {loaded} />
 	{/if}

--- a/src/components/AppShell.svelte
+++ b/src/components/AppShell.svelte
@@ -7,6 +7,7 @@
 	import { playChime, unlockAudio } from '../sound.ts';
 	import { liveStream } from '../live.ts';
 	import { apiPost } from '../api.ts';
+	import toast, { Toaster } from 'svelte-french-toast';
 
 	// `initialPath` is the URL the document was served for; `snapshot` is the
 	// reconciled instance list at render time, used to seed the live state so both
@@ -62,7 +63,7 @@
 			await apiPost(`/api/instances/${id}/rename`, { name }, 'Failed to rename');
 			// The SSE stream reflects the new name.
 		} catch (err) {
-			console.error('Failed to rename', err);
+			toast.error((err as Error).message);
 		}
 	}
 
@@ -250,6 +251,16 @@
 		{/if}
 	</div>
 </div>
+
+<!-- Hoisted here (rather than DashboardView) so it stays mounted across both
+     routes — toasts raised from the IDE tab bar (e.g. a failed rename) need
+     somewhere to render too. -->
+<Toaster
+	toastOptions={{
+		style:
+			'border:1px solid var(--ink); background:var(--bg-card); color:var(--ink); box-shadow:4px 4px 0 var(--ink); font-family:var(--font-mono); font-size:13px;'
+	}}
+/>
 
 <style>
 	/* On the IDE route the app is a fixed-height column (bar + panes fill the

--- a/src/components/DashboardView.svelte
+++ b/src/components/DashboardView.svelte
@@ -5,7 +5,6 @@
 	import TopBar from './TopBar.svelte';
 	import Button from './Button.svelte';
 	import Plus from '@lucide/svelte/icons/plus';
-	import { Toaster } from 'svelte-french-toast';
 	import { apiPost } from '../api.ts';
 
 	// Instances and their load state come from the persistent AppShell (single SSE
@@ -141,13 +140,6 @@
 {#if browserOpen}
 	<FolderBrowser onpick={createFrom} onclose={() => (browserOpen = false)} />
 {/if}
-
-<Toaster
-	toastOptions={{
-		style:
-			'border:1px solid var(--ink); background:var(--bg-card); color:var(--ink); box-shadow:4px 4px 0 var(--ink); font-family:var(--font-mono); font-size:13px;'
-	}}
-/>
 
 <style>
 	.stage {

--- a/src/components/IdeBar.svelte
+++ b/src/components/IdeBar.svelte
@@ -8,12 +8,22 @@
 		running,
 		active,
 		attention,
-		onselect
+		editingId,
+		editingName = $bindable(),
+		onselect,
+		onstartrename,
+		oncommitrename,
+		oncancelrename
 	}: {
 		running: Instance[];
 		active: string;
 		attention: Record<string, 'done' | 'waiting' | null>;
+		editingId: string | null;
+		editingName: string;
 		onselect: (id: string) => void;
+		onstartrename: (instance: Instance) => void;
+		oncommitrename: (id: string) => void;
+		oncancelrename: () => void;
 	} = $props();
 </script>
 
@@ -27,15 +37,33 @@
 					class:attn-done={inst.id !== active && attention[inst.id] === 'done'}
 					class:attn-waiting={inst.id !== active && attention[inst.id] === 'waiting'}
 				>
-					<button
-						type="button"
-						class="tab-label"
-						onclick={() => onselect(inst.id)}
-						title={inst.name}
-					>
-						<Avatar id={inst.id} name={inst.name} scale={4} />
-						<span class="tab-name">{inst.name}</span>
-					</button>
+					{#if editingId === inst.id}
+						<div class="tab-label editing">
+							<Avatar id={inst.id} name={inst.name} scale={4} />
+							<!-- svelte-ignore a11y_autofocus -->
+							<input
+								class="tab-name-edit"
+								bind:value={editingName}
+								autofocus
+								onblur={() => oncommitrename(inst.id)}
+								onkeydown={(e) => {
+									if (e.key === 'Enter') (e.currentTarget as HTMLInputElement).blur();
+									else if (e.key === 'Escape') oncancelrename();
+								}}
+							/>
+						</div>
+					{:else}
+						<button
+							type="button"
+							class="tab-label"
+							onclick={() => onselect(inst.id)}
+							ondblclick={() => onstartrename(inst)}
+							title={inst.name}
+						>
+							<Avatar id={inst.id} name={inst.name} scale={4} />
+							<span class="tab-name">{inst.name}</span>
+						</button>
+					{/if}
 				</div>
 			{/each}
 		</nav>
@@ -138,5 +166,21 @@
 	}
 	.tab.active .tab-label {
 		color: var(--bg);
+	}
+	.tab-label.editing {
+		cursor: default;
+	}
+	.tab-name-edit {
+		width: 130px;
+		font-family: var(--font-mono);
+		font-size: 12px;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		margin: 0;
+		padding: 2px 4px;
+		border: 1px solid var(--ink-soft);
+		background: var(--bg);
+		color: var(--ink);
+		outline: none;
 	}
 </style>


### PR DESCRIPTION
## Summary
- Double-clicking an instance's name in the IDE tab bar now swaps it for an inline input, editable in place.
- Enter commits the new name (via the existing `/api/instances/:id/rename` endpoint), Escape cancels, and blurring elsewhere also commits — mirroring the rename pattern already used on the dashboard's `InstanceCard`.
- No server-side changes needed; reuses the existing rename endpoint and dedup-by-suffix logic.

## Test plan
- [x] `bun run checks` (format, typecheck, tests) passes
- [x] Manually verify in browser: double-click a tab name, edit, press Enter, confirm it updates and persists