### PR TITLE
Add bob-marley avatar contribution

### DIFF
--- a/src/avatars/bob-marley.ts
+++ b/src/avatars/bob-marley.ts
@@ -1,0 +1,17 @@
+import type { AvatarArt } from './types.ts';
+
+const art: AvatarArt = {
+	name: 'bob-marley',
+	pixels: [
+		'..####..',
+		'.######.',
+		'##....##',
+		'#.#..#.#',
+		'#......#',
+		'##.##.##',
+		'#.####.#',
+		'#..##..#'
+	]
+};
+
+export default art;

--- a/src/avatars/index.ts
+++ b/src/avatars/index.ts
@@ -5,6 +5,7 @@ import type { AvatarArt } from './types.ts';
 import anchor from './anchor.ts';
 import bear from './bear.ts';
 import bee from './bee.ts';
+import bobMarley from './bob-marley.ts';
 import cat from './cat.ts';
 import cherry from './cherry.ts';
 import crab from './crab.ts';
@@ -41,6 +42,7 @@ export const avatars: AvatarArt[] = [
 	anchor,
 	bear,
 	bee,
+	bobMarley,
 	cat,
 	cherry,
 	crab,


### PR DESCRIPTION
## Summary
- Adds the community-submitted `bob-marley` sprite from the avatar-editor easter egg
- Wires it into the `avatars[]` catalog in alphabetical order (`bee` → `bob-marley` → `cat`)

Closes #13

## Test plan
- [x] `bun run checks` (format + typecheck + tests) passes, including `src/avatars/avatars.test.ts` (8×8 size, `#`/`.` charset, unique name)