### PR TITLE
Add cat-body avatar contribution

### DIFF
--- a/src/avatars/cat-body.ts
+++ b/src/avatars/cat-body.ts
@@ -1,0 +1,17 @@
+import type { AvatarArt } from './types.ts';
+
+const art: AvatarArt = {
+	name: 'cat-body',
+	pixels: [
+		'....##..',
+		'#.#..###',
+		'###....#',
+		'###..###',
+		'########',
+		'########',
+		'#.#..#.#',
+		'#.#..#.#'
+	]
+};
+
+export default art;

--- a/src/avatars/index.ts
+++ b/src/avatars/index.ts
@@ -7,6 +7,7 @@ import bear from './bear.ts';
 import bee from './bee.ts';
 import bobMarley from './bob-marley.ts';
 import cat from './cat.ts';
+import catBody from './cat-body.ts';
 import cherry from './cherry.ts';
 import crab from './crab.ts';
 import crown from './crown.ts';
@@ -44,6 +45,7 @@ export const avatars: AvatarArt[] = [
 	bee,
 	bobMarley,
 	cat,
+	catBody,
 	cherry,
 	crab,
 	crown,


### PR DESCRIPTION
Closes #12

Adds the community-submitted `cat-body` avatar sprite from the avatar-editor easter egg and registers it in the catalog.