### PR TITLE
Add bunny-body avatar contribution

### DIFF
--- a/src/avatars/bunny-body.ts
+++ b/src/avatars/bunny-body.ts
@@ -1,0 +1,17 @@
+import type { AvatarArt } from './types.ts';
+
+const art: AvatarArt = {
+	name: 'bunny-body',
+	pixels: [
+		'.#.#....',
+		'.#.#....',
+		'.###....',
+		'.####...',
+		'.#####.#',
+		'.#######',
+		'.######.',
+		'..##.##.'
+	]
+};
+
+export default art;

--- a/src/avatars/index.ts
+++ b/src/avatars/index.ts
@@ -6,6 +6,7 @@ import anchor from './anchor.ts';
 import bear from './bear.ts';
 import bee from './bee.ts';
 import bobMarley from './bob-marley.ts';
+import bunnyBody from './bunny-body.ts';
 import cat from './cat.ts';
 import catBody from './cat-body.ts';
 import cherry from './cherry.ts';
@@ -44,6 +45,7 @@ export const avatars: AvatarArt[] = [
 	bear,
 	bee,
 	bobMarley,
+	bunnyBody,
 	cat,
 	catBody,
 	cherry,


### PR DESCRIPTION
Adds a `bunny-body` avatar sprite and registers it in the catalog, following the same pattern as #17 (`cat-body`). A sitting bunny in side profile — upright ears, round body, notched fluffy tail, and paws — as a full-body companion to the existing `rabbit` face.

```
.#.#....
.#.#....
.###....
.####...
.#####.#
.#######
.######.
..##.##.
```

`bun run checks` passes: 78/78 tests, typecheck and format clean.

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple