### PR TITLE
Add kangaroo avatar contribution

### DIFF
--- a/src/avatars/index.ts
+++ b/src/avatars/index.ts
@@ -20,6 +20,7 @@ import frog from './frog.ts';
 import ghost from './ghost.ts';
 import heart from './heart.ts';
 import invader from './invader.ts';
+import kangaroo from './kangaroo.ts';
 import key from './key.ts';
 import lightning from './lightning.ts';
 import mushroom from './mushroom.ts';
@@ -58,6 +59,7 @@ export const avatars: AvatarArt[] = [
 	ghost,
 	heart,
 	invader,
+	kangaroo,
 	key,
 	lightning,
 	mushroom,

--- a/src/avatars/kangaroo.ts
+++ b/src/avatars/kangaroo.ts
@@ -1,0 +1,17 @@
+import type { AvatarArt } from './types.ts';
+
+const art: AvatarArt = {
+	name: 'kangaroo',
+	pixels: [
+		'..#.#...',
+		'..###...',
+		'.####...',
+		'...##...',
+		'..#####.',
+		'...####.',
+		'...##.#.',
+		'..###..#'
+	]
+};
+
+export default art;


### PR DESCRIPTION
Adds a `kangaroo` avatar sprite and registers it in the catalog, same pattern as #17 (`cat-body`). Side profile, leaning back on its tail: upright ears, snout, front paw, big haunch, and the tail running to the ground behind the foot.

```
..#.#...
..###...
.####...
...##...
..#####.
...####.
...##.#.
..###..#
```

`bun run checks` passes: 78/78 tests, typecheck and format clean.

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple