### PR TITLE
Make port allocation check live Docker state, not just the DB

### DIFF
--- a/src/lib/docker.isolated.test.ts
+++ b/src/lib/docker.isolated.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import { removeContainer } from './docker.server.ts';
+import { hostPortsInUse, removeContainer } from './docker.server.ts';
 
 /**
  * `getDocker()` resolves a dockerode client pinned to `globalThis.__codebayDocker`.
@@ -105,5 +105,47 @@ describe('removeContainer', () => {
 		});
 		expect(await removeContainer('c1')).toBe(true);
 		expect(calls.volumesRemoved).toEqual(['v1']);
+	});
+});
+
+describe('hostPortsInUse', () => {
+	afterEach(() => {
+		g.__codebayDocker = undefined;
+	});
+
+	test('collects published host ports across every running container, deduped', async () => {
+		g.__codebayDocker = Promise.resolve({
+			listContainers: async () => [
+				{ Ports: [{ PrivatePort: 8080, PublicPort: 8001, Type: 'tcp' }] },
+				{
+					Ports: [
+						{ PrivatePort: 3333, PublicPort: 8002, Type: 'tcp' },
+						{ PrivatePort: 8080, PublicPort: 8001, Type: 'tcp' } // dup, e.g. seen on two networks
+					]
+				}
+			]
+		});
+		expect((await hostPortsInUse()).sort()).toEqual([8001, 8002]);
+	});
+
+	test('skips exposed-but-not-published ports (no PublicPort)', async () => {
+		g.__codebayDocker = Promise.resolve({
+			listContainers: async () => [{ Ports: [{ PrivatePort: 8080, Type: 'tcp' }] }]
+		});
+		expect(await hostPortsInUse()).toEqual([]);
+	});
+
+	test('returns [] when a container has no Ports field', async () => {
+		g.__codebayDocker = Promise.resolve({ listContainers: async () => [{}] });
+		expect(await hostPortsInUse()).toEqual([]);
+	});
+
+	test('returns [] when the daemon is unreachable', async () => {
+		g.__codebayDocker = Promise.resolve({
+			listContainers: async () => {
+				throw new Error('connect ECONNREFUSED');
+			}
+		});
+		expect(await hostPortsInUse()).toEqual([]);
 	});
 });

--- a/src/lib/docker.server.ts
+++ b/src/lib/docker.server.ts
@@ -73,6 +73,31 @@ export async function publishedContainerPorts(containerId: string): Promise<numb
 }
 
 /**
+ * Every host port currently published by any *running* container on the daemon,
+ * regardless of whether codebay's DB has a row for it. `allocatePort` unions this
+ * with the DB-derived set so a container the daemon still has bound — e.g. one
+ * orphaned by an app restart that lost its DB row, or started outside codebay
+ * entirely — can never be handed out to a new instance. Stopped containers don't
+ * hold their bind, so `listContainers()`'s running-only default is exactly what's
+ * needed here. Returns `[]` on any failure (daemon unreachable) rather than
+ * throwing — allocation still works from the DB view alone in that case.
+ */
+export async function hostPortsInUse(): Promise<number[]> {
+	try {
+		const containers = await (await getDocker()).listContainers();
+		const ports = new Set<number>();
+		for (const c of containers) {
+			for (const p of c.Ports ?? []) {
+				if (p.PublicPort) ports.add(p.PublicPort);
+			}
+		}
+		return [...ports];
+	} catch {
+		return [];
+	}
+}
+
+/**
  * Purge BuildKit's build cache (the layer cache `devcontainer up` reuses), so the
  * next build runs uncached. Hits `POST /build/prune?all=true` via the raw modem —
  * dockerode has no dedicated helper for it. Returns the bytes reclaimed. Does not

--- a/src/lib/instances.server.ts
+++ b/src/lib/instances.server.ts
@@ -1,13 +1,6 @@
 import { rm, stat } from 'node:fs/promises';
 import { basename, join } from 'node:path';
-import {
-	CODE_SERVER_PORT,
-	DATA_DIR,
-	DEFAULT_IMAGE,
-	INSTANCES_DIR,
-	PORT_BASE,
-	PORT_MAX
-} from './config.server.ts';
+import { CODE_SERVER_PORT, DATA_DIR, DEFAULT_IMAGE, INSTANCES_DIR } from './config.server.ts';
 import {
 	allForwards,
 	allInstances,
@@ -47,6 +40,7 @@ import { injections } from './injections.server.ts';
 import { cloneRepo, readGitBranch } from './git.server.ts';
 import { isRepoUrl, parseRepoUrl } from './repo-url.ts';
 import { currentHealthSnapshots, stopHealthMonitor, syncHealthMonitors } from './health.server.ts';
+import { pickFreePort } from './ports.server.ts';
 import type { ServerWebSocket } from 'bun';
 import type { Instance, InstanceHealth } from '../types.ts';
 
@@ -269,13 +263,9 @@ async function allocatePort(): Promise<number> {
 	for (const [port, reservedAt] of reservedPorts) {
 		if (dbPorts.has(port) || now - reservedAt > RESERVATION_TTL_MS) reservedPorts.delete(port);
 	}
-	for (let port = PORT_BASE; port <= PORT_MAX; port++) {
-		if (!dbPorts.has(port) && !dockerPorts.has(port) && !reservedPorts.has(port)) {
-			reservedPorts.set(port, now);
-			return port;
-		}
-	}
-	throw new Error('No free host ports available.');
+	const port = pickFreePort([dbPorts, dockerPorts, new Set(reservedPorts.keys())]);
+	reservedPorts.set(port, now);
+	return port;
 }
 
 /** Validate that a path exists and is a directory. */

--- a/src/lib/instances.server.ts
+++ b/src/lib/instances.server.ts
@@ -28,6 +28,7 @@ import {
 } from './db.server.ts';
 import {
 	dockerAvailable,
+	hostPortsInUse,
 	isRunning,
 	removeContainer,
 	startContainer,
@@ -247,12 +248,20 @@ export function streamClose(ws: ServerWebSocket<unknown>): void {
 // forever and permanently shrink the range. So we also drop any reservation older
 // than the TTL: far longer than any real allocate→insert gap, but a hard backstop
 // against leaking the range on a failed insert.
+//
+// The DB is *not* the ground truth for what's actually bound on the host, though —
+// a container can outlive its DB row (e.g. codebay restarted with a DB that lost
+// track of it, or the container was started outside codebay) and keep holding its
+// port indefinitely. So we also union in `hostPortsInUse()`, which asks Docker
+// directly what's currently published; that's the set that can actually make
+// `docker run -p` fail, independent of whatever codebay's own bookkeeping thinks.
 const RESERVATION_TTL_MS = 60_000;
 const globalForPorts = globalThis as unknown as { __codebayReservedPorts?: Map<number, number> };
 const reservedPorts: Map<number, number> = (globalForPorts.__codebayReservedPorts ??= new Map());
 
-function allocatePort(): number {
+async function allocatePort(): Promise<number> {
 	const dbPorts = new Set(usedPorts());
+	const dockerPorts = new Set(await hostPortsInUse());
 	const now = Date.now();
 	// Drop reservations that have already been persisted (now covered by the DB set)
 	// or that have aged past the TTL (their insert never landed) — either way keeping
@@ -261,7 +270,7 @@ function allocatePort(): number {
 		if (dbPorts.has(port) || now - reservedAt > RESERVATION_TTL_MS) reservedPorts.delete(port);
 	}
 	for (let port = PORT_BASE; port <= PORT_MAX; port++) {
-		if (!dbPorts.has(port) && !reservedPorts.has(port)) {
+		if (!dbPorts.has(port) && !dockerPorts.has(port) && !reservedPorts.has(port)) {
 			reservedPorts.set(port, now);
 			return port;
 		}
@@ -318,7 +327,7 @@ async function seedDeclaredPorts(row: InstanceRow): Promise<void> {
 	const existing = new Set(listForwards(row.id).map((f) => f.container_port));
 	for (const containerPort of await readDeclaredContainerPorts(row.workspace_path)) {
 		if (existing.has(containerPort)) continue;
-		const hostPort = allocatePort();
+		const hostPort = await allocatePort();
 		insertForward({
 			instance_id: row.id,
 			container_port: containerPort,
@@ -434,12 +443,13 @@ export async function createInstance(
 	}
 	const id = crypto.randomUUID();
 	const folderName = parsedRepo?.repo || basename(source) || 'workspace';
+	const hostPort = await allocatePort();
 	const row: InstanceRow = {
 		id,
 		name: uniqueName(name?.trim() || folderName),
 		source_path: source,
 		workspace_path: join(INSTANCES_DIR, id, folderName),
-		host_port: allocatePort(),
+		host_port: hostPort,
 		container_id: null,
 		remote_workspace_folder: null,
 		status: 'creating',
@@ -520,7 +530,7 @@ export function renameInstance(id: string, name: string): InstanceRow {
 }
 
 /** Allocate a host port for a new container port and persist it. Apply via `rebuildInstance`. */
-export function addForwardedPort(id: string, containerPort: number): InstanceRow {
+export async function addForwardedPort(id: string, containerPort: number): Promise<InstanceRow> {
 	const row = getInstance(id);
 	if (!row) throw new Error('Instance not found');
 	if (!Number.isInteger(containerPort) || containerPort < 1 || containerPort > 65535) {
@@ -535,7 +545,7 @@ export function addForwardedPort(id: string, containerPort: number): InstanceRow
 	insertForward({
 		instance_id: id,
 		container_port: containerPort,
-		host_port: allocatePort(),
+		host_port: await allocatePort(),
 		created_at: Date.now()
 	});
 	triggerReconcile();

--- a/src/lib/ports.isolated.test.ts
+++ b/src/lib/ports.isolated.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+import { PORT_BASE, PORT_MAX } from './config.server.ts';
+import { pickFreePort } from './ports.server.ts';
+
+describe('pickFreePort', () => {
+	test('returns PORT_BASE when nothing is in use', () => {
+		expect(pickFreePort([])).toBe(PORT_BASE);
+	});
+
+	test('skips a port from every supplied set, not just the first', () => {
+		// Mirrors allocatePort's DB ∪ Docker ∪ reservations union: a port only Docker
+		// reports (e.g. a container the DB lost track of) must still be excluded, exactly
+		// like one only the DB or only an in-flight reservation knows about.
+		const dbPorts = new Set([PORT_BASE]);
+		const dockerOnlyPort = new Set([PORT_BASE + 1]);
+		const reserved = new Set([PORT_BASE + 2]);
+		expect(pickFreePort([dbPorts, dockerOnlyPort, reserved])).toBe(PORT_BASE + 3);
+	});
+
+	test('throws once the whole range is exhausted', () => {
+		const all = new Set<number>();
+		for (let port = PORT_BASE; port <= PORT_MAX; port++) all.add(port);
+		expect(() => pickFreePort([all])).toThrow('No free host ports available.');
+	});
+});

--- a/src/lib/ports.server.ts
+++ b/src/lib/ports.server.ts
@@ -1,0 +1,14 @@
+import { PORT_BASE, PORT_MAX } from './config.server.ts';
+
+/**
+ * Pick the lowest port in [PORT_BASE, PORT_MAX] absent from every set in `usedSets`.
+ * Pure and side-effect free so `allocatePort`'s union logic (DB rows ∪ live Docker
+ * bindings ∪ in-flight reservations) is unit-testable without a live DB or Docker
+ * daemon — see ports.isolated.test.ts.
+ */
+export function pickFreePort(usedSets: ReadonlySet<number>[]): number {
+	for (let port = PORT_BASE; port <= PORT_MAX; port++) {
+		if (usedSets.every((s) => !s.has(port))) return port;
+	}
+	throw new Error('No free host ports available.');
+}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -276,7 +276,7 @@ export const routes: Record<string, MochiRouteValue> = {
 	'/api/instances/:id/ports': mutationRoute('POST', async ({ params, request }) => {
 		const body = (await request.json().catch(() => null)) as { port?: number } | null;
 		if (typeof body?.port !== 'number') throw new Error('port (number) is required');
-		return { instance: sanitizeInstance(addForwardedPort(params.id!, body.port)) };
+		return { instance: sanitizeInstance(await addForwardedPort(params.id!, body.port)) };
 	}),
 
 	'/api/instances/:id/ports/:port': mutationRoute('DELETE', ({ params }) => {


### PR DESCRIPTION
## Summary
- `allocatePort()` previously only checked host ports recorded in the `instances`/`port_forwards` tables. If a container Docker still has running falls out of the DB's view (e.g. codebay loses track of an instance across a restart), its port looked "free" and could be handed to a new instance, making `devcontainer up` fail with `Bind for 127.0.0.1:<port> failed: port is already allocated`.
- Added `hostPortsInUse()` (`src/lib/docker.server.ts`), which asks the Docker daemon directly (`listContainers()`, running-only) for every currently-published host port, independent of codebay's own bookkeeping.
- `allocatePort()` now unions the DB-derived set with `hostPortsInUse()` before picking a free port. Made it `async` and updated its three call sites (`seedDeclaredPorts`, `createInstance`, `addForwardedPort`) plus the one route caller accordingly.

## Test plan
- [x] `bun run checks` (format, typecheck, full test suite) passes
- [x] Added `hostPortsInUse` tests: dedup across containers, exposed-but-unpublished ports, missing `Ports` field, daemon-unreachable fallback