### PR TITLE
Add cat-sits avatar contribution

### DIFF
--- a/src/avatars/cat-sits.ts
+++ b/src/avatars/cat-sits.ts
@@ -1,0 +1,17 @@
+import type { AvatarArt } from './types.ts';
+
+const art: AvatarArt = {
+	name: 'cat-sits',
+	pixels: [
+		'..#..#..',
+		'..####..',
+		'..####..',
+		'.####...',
+		'####..##',
+		'####.#.#',
+		'####...#',
+		'.######.'
+	]
+};
+
+export default art;

--- a/src/avatars/index.ts
+++ b/src/avatars/index.ts
@@ -8,6 +8,7 @@ import bee from './bee.ts';
 import bobMarley from './bob-marley.ts';
 import cat from './cat.ts';
 import catBody from './cat-body.ts';
+import catSits from './cat-sits.ts';
 import cherry from './cherry.ts';
 import crab from './crab.ts';
 import crown from './crown.ts';
@@ -47,6 +48,7 @@ export const avatars: AvatarArt[] = [
 	bobMarley,
 	cat,
 	catBody,
+	catSits,
 	cherry,
 	crab,
 	crown,


### PR DESCRIPTION
Closes #20

## Summary
- Adds the `cat-sits` avatar sprite submitted via the avatar-editor easter egg
- Registers it in `src/avatars/index.ts` (alphabetical position: after `cat-body`, before `cherry`)

## Test plan
- [x] `bun run checks` (format + typecheck + tests) passes, including `avatars.test.ts`'s 8x8/charset/uniqueness checks