### PR TITLE
Add celtic-cross avatar contribution

### DIFF
--- a/src/avatars/celtic-cross.ts
+++ b/src/avatars/celtic-cross.ts
@@ -1,0 +1,17 @@
+import type { AvatarArt } from './types.ts';
+
+const art: AvatarArt = {
+	name: 'celtic-cross',
+	pixels: [
+		'...##...',
+		'.#.##.#.',
+		'...##...',
+		'########',
+		'########',
+		'...##...',
+		'.#.##.#.',
+		'...##...'
+	]
+};
+
+export default art;

--- a/src/avatars/index.ts
+++ b/src/avatars/index.ts
@@ -8,6 +8,7 @@ import bee from './bee.ts';
 import bobMarley from './bob-marley.ts';
 import cat from './cat.ts';
 import catBody from './cat-body.ts';
+import celticCross from './celtic-cross.ts';
 import cherry from './cherry.ts';
 import crab from './crab.ts';
 import crown from './crown.ts';
@@ -47,6 +48,7 @@ export const avatars: AvatarArt[] = [
 	bobMarley,
 	cat,
 	catBody,
+	celticCross,
 	cherry,
 	crab,
 	crown,


### PR DESCRIPTION
Closes #21

## Summary
- Adds the `celtic-cross` avatar sprite submitted via the avatar-editor easter egg
- Registers it in `src/avatars/index.ts` (alphabetical position: after `cat-body`, before `cherry`)

## Test plan
- [x] `bun run checks` (format + typecheck + tests) passes, including `avatars.test.ts`'s 8x8/charset/uniqueness checks