### PR TITLE
Add fleur-de-lis avatar contribution

### DIFF
--- a/src/avatars/fleur-de-lis.ts
+++ b/src/avatars/fleur-de-lis.ts
@@ -1,0 +1,17 @@
+import type { AvatarArt } from './types.ts';
+
+const art: AvatarArt = {
+	name: 'fleur-de-lis',
+	pixels: [
+		'...##...',
+		'...#....',
+		'.###.##.',
+		'#.##...#',
+		'...##...',
+		'.#.##.#.',
+		'.######.',
+		'...##...'
+	]
+};
+
+export default art;

--- a/src/avatars/index.ts
+++ b/src/avatars/index.ts
@@ -16,6 +16,7 @@ import crown from './crown.ts';
 import diamond from './diamond.ts';
 import dog from './dog.ts';
 import fish from './fish.ts';
+import fleurDeLis from './fleur-de-lis.ts';
 import flower from './flower.ts';
 import fox from './fox.ts';
 import frog from './frog.ts';
@@ -57,6 +58,7 @@ export const avatars: AvatarArt[] = [
 	diamond,
 	dog,
 	fish,
+	fleurDeLis,
 	flower,
 	fox,
 	frog,


### PR DESCRIPTION
Closes #26

## Summary
- Adds the `fleur-de-lis` avatar sprite submitted via the avatar-editor easter egg
- Registers it in `src/avatars/index.ts` (alphabetical position: after `fish`, before `flower`)

## Test plan
- [x] `bun run checks` (format + typecheck + tests) passes, including `avatars.test.ts`'s 8x8/charset/uniqueness checks