### PR TITLE
Add ukraine avatar contribution

### DIFF
--- a/src/avatars/index.ts
+++ b/src/avatars/index.ts
@@ -39,6 +39,7 @@ import snail from './snail.ts';
 import star from './star.ts';
 import target from './target.ts';
 import tree from './tree.ts';
+import ukraine from './ukraine.ts';
 import whale from './whale.ts';
 
 // Order is stable: a given id always resolves to the same index, so the artwork
@@ -81,6 +82,7 @@ export const avatars: AvatarArt[] = [
 	star,
 	target,
 	tree,
+	ukraine,
 	whale
 ];
 

--- a/src/avatars/ukraine.ts
+++ b/src/avatars/ukraine.ts
@@ -1,0 +1,17 @@
+import type { AvatarArt } from './types.ts';
+
+const art: AvatarArt = {
+	name: 'ukraine',
+	pixels: [
+		'...##...',
+		'#..##..#',
+		'##.##.##',
+		'#..##..#',
+		'##.##.##',
+		'#..##..#',
+		'########',
+		'...##...'
+	]
+};
+
+export default art;


### PR DESCRIPTION
Closes #27

## Summary
- Adds the `ukraine` avatar sprite submitted via the avatar-editor easter egg
- Registers it in `src/avatars/index.ts` (alphabetical position: after `tree`, before `whale`)

## Test plan
- [x] `bun run checks` (format + typecheck + tests) passes, including `avatars.test.ts`'s 8x8/charset/uniqueness checks