### PR TITLE
Add 13 community avatar contributions

### DIFF
--- a/src/avatars/car.ts
+++ b/src/avatars/car.ts
@@ -1,0 +1,17 @@
+import type { AvatarArt } from './types.ts';
+
+const art: AvatarArt = {
+	name: 'car',
+	pixels: [
+		'........',
+		'..####..',
+		'..#..#..',
+		'..#..#..',
+		'########',
+		'########',
+		'########',
+		'.##..##.'
+	]
+};
+
+export default art;

--- a/src/avatars/carpathians.ts
+++ b/src/avatars/carpathians.ts
@@ -1,0 +1,17 @@
+import type { AvatarArt } from './types.ts';
+
+const art: AvatarArt = {
+	name: 'carpathians',
+	pixels: [
+		'........',
+		'.#......',
+		'......##',
+		'.....###',
+		'#...####',
+		'##.#####',
+		'###.####',
+		'####.###'
+	]
+};
+
+export default art;

--- a/src/avatars/cotton.ts
+++ b/src/avatars/cotton.ts
@@ -1,0 +1,17 @@
+import type { AvatarArt } from './types.ts';
+
+const art: AvatarArt = {
+	name: 'cotton',
+	pixels: [
+		'....##..',
+		'....##..',
+		'.##.....',
+		'.##..##.',
+		'...#.##.',
+		'....#...',
+		'...#....',
+		'...#....'
+	]
+};
+
+export default art;

--- a/src/avatars/elephant.ts
+++ b/src/avatars/elephant.ts
@@ -1,0 +1,17 @@
+import type { AvatarArt } from './types.ts';
+
+const art: AvatarArt = {
+	name: 'elephant',
+	pixels: [
+		'...###..',
+		'.#####..',
+		'####.#..',
+		'######..',
+		'######.#',
+		'##.##.#.',
+		'##.##...',
+		'##.##...'
+	]
+};
+
+export default art;

--- a/src/avatars/giraffe.ts
+++ b/src/avatars/giraffe.ts
@@ -1,0 +1,17 @@
+import type { AvatarArt } from './types.ts';
+
+const art: AvatarArt = {
+	name: 'giraffe',
+	pixels: [
+		'....#.#.',
+		'....####',
+		'....#...',
+		'....#...',
+		'....#...',
+		'....#...',
+		'#####...',
+		'##.##...'
+	]
+};
+
+export default art;

--- a/src/avatars/glasses.ts
+++ b/src/avatars/glasses.ts
@@ -1,0 +1,17 @@
+import type { AvatarArt } from './types.ts';
+
+const art: AvatarArt = {
+	name: 'glasses',
+	pixels: [
+		'##..##..',
+		'#.#.##.#',
+		'.#######',
+		'........',
+		'.##..##.',
+		'.##..##.',
+		'#..##..#',
+		'########'
+	]
+};
+
+export default art;

--- a/src/avatars/index.ts
+++ b/src/avatars/index.ts
@@ -6,21 +6,27 @@ import anchor from './anchor.ts';
 import bear from './bear.ts';
 import bee from './bee.ts';
 import bobMarley from './bob-marley.ts';
+import car from './car.ts';
+import carpathians from './carpathians.ts';
 import cat from './cat.ts';
 import catBody from './cat-body.ts';
 import catSits from './cat-sits.ts';
 import celticCross from './celtic-cross.ts';
 import cherry from './cherry.ts';
+import cotton from './cotton.ts';
 import crab from './crab.ts';
 import crown from './crown.ts';
 import diamond from './diamond.ts';
 import dog from './dog.ts';
+import elephant from './elephant.ts';
 import fish from './fish.ts';
 import fleurDeLis from './fleur-de-lis.ts';
 import flower from './flower.ts';
 import fox from './fox.ts';
 import frog from './frog.ts';
 import ghost from './ghost.ts';
+import giraffe from './giraffe.ts';
+import glasses from './glasses.ts';
 import heart from './heart.ts';
 import invader from './invader.ts';
 import kangaroo from './kangaroo.ts';
@@ -32,15 +38,22 @@ import owl from './owl.ts';
 import penguin from './penguin.ts';
 import planet from './planet.ts';
 import rabbit from './rabbit.ts';
+import rat from './rat.ts';
 import robot from './robot.ts';
 import rocket from './rocket.ts';
+import sea from './sea.ts';
 import skull from './skull.ts';
 import snail from './snail.ts';
+import snake from './snake.ts';
+import snakegame from './snakegame.ts';
 import star from './star.ts';
+import svelte from './svelte.ts';
 import target from './target.ts';
 import tree from './tree.ts';
 import ukraine from './ukraine.ts';
 import whale from './whale.ts';
+import wheat from './wheat.ts';
+import yinyan from './yinyan.ts';
 
 // Order is stable: a given id always resolves to the same index, so the artwork
 // for a container never changes between renders or restarts.
@@ -49,21 +62,27 @@ export const avatars: AvatarArt[] = [
 	bear,
 	bee,
 	bobMarley,
+	car,
+	carpathians,
 	cat,
 	catBody,
 	catSits,
 	celticCross,
 	cherry,
+	cotton,
 	crab,
 	crown,
 	diamond,
 	dog,
+	elephant,
 	fish,
 	fleurDeLis,
 	flower,
 	fox,
 	frog,
 	ghost,
+	giraffe,
+	glasses,
 	heart,
 	invader,
 	kangaroo,
@@ -75,15 +94,22 @@ export const avatars: AvatarArt[] = [
 	penguin,
 	planet,
 	rabbit,
+	rat,
 	robot,
 	rocket,
+	sea,
 	skull,
 	snail,
+	snake,
+	snakegame,
 	star,
+	svelte,
 	target,
 	tree,
 	ukraine,
-	whale
+	whale,
+	wheat,
+	yinyan
 ];
 
 // FNV-1a (32-bit) — a fast, well-distributed hash. Pure function of the input

--- a/src/avatars/rat.ts
+++ b/src/avatars/rat.ts
@@ -1,0 +1,17 @@
+import type { AvatarArt } from './types.ts';
+
+const art: AvatarArt = {
+	name: 'rat',
+	pixels: [
+		'...#.#..',
+		'...#####',
+		'...#.#..',
+		'..###...',
+		'.####.#.',
+		'#####..#',
+		'####..#.',
+		'.#####..'
+	]
+};
+
+export default art;

--- a/src/avatars/sea.ts
+++ b/src/avatars/sea.ts
@@ -1,0 +1,17 @@
+import type { AvatarArt } from './types.ts';
+
+const art: AvatarArt = {
+	name: 'sea',
+	pixels: [
+		'#.#.....',
+		'.#..#.#.',
+		'.....#..',
+		'...#....',
+		'........',
+		'########',
+		'.##..###',
+		'##.###..'
+	]
+};
+
+export default art;

--- a/src/avatars/snake.ts
+++ b/src/avatars/snake.ts
@@ -1,0 +1,17 @@
+import type { AvatarArt } from './types.ts';
+
+const art: AvatarArt = {
+	name: 'snake',
+	pixels: [
+		'...###..',
+		'.###..#.',
+		'#.#..#..',
+		'##..#..#',
+		'...#..#.',
+		'..#...##',
+		'.#.....#',
+		'.######.'
+	]
+};
+
+export default art;

--- a/src/avatars/snakegame.ts
+++ b/src/avatars/snakegame.ts
@@ -1,0 +1,17 @@
+import type { AvatarArt } from './types.ts';
+
+const art: AvatarArt = {
+	name: 'snakegame',
+	pixels: [
+		'########',
+		'#......#',
+		'#.##...#',
+		'#.#..#.#',
+		'#.##...#',
+		'#..##..#',
+		'#......#',
+		'########'
+	]
+};
+
+export default art;

--- a/src/avatars/svelte.ts
+++ b/src/avatars/svelte.ts
@@ -1,0 +1,17 @@
+import type { AvatarArt } from './types.ts';
+
+const art: AvatarArt = {
+	name: 'svelte',
+	pixels: [
+		'..#####.',
+		'.###..#.',
+		'##...#..',
+		'########',
+		'########',
+		'..#...##',
+		'.#..###.',
+		'.####...'
+	]
+};
+
+export default art;

--- a/src/avatars/wheat.ts
+++ b/src/avatars/wheat.ts
@@ -1,0 +1,17 @@
+import type { AvatarArt } from './types.ts';
+
+const art: AvatarArt = {
+	name: 'wheat',
+	pixels: [
+		'........',
+		'....#.#.',
+		'...#.#..',
+		'..#.#.#.',
+		'..##.#..',
+		'..###...',
+		'.#......',
+		'#.......'
+	]
+};
+
+export default art;

--- a/src/avatars/yinyan.ts
+++ b/src/avatars/yinyan.ts
@@ -1,0 +1,17 @@
+import type { AvatarArt } from './types.ts';
+
+const art: AvatarArt = {
+	name: 'yinyan',
+	pixels: [
+		'.......#',
+		'.##...##',
+		'.##..###',
+		'....####',
+		'...#####',
+		'..###..#',
+		'.####..#',
+		'########'
+	]
+};
+
+export default art;


### PR DESCRIPTION
Closes #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42

Batches all currently-open avatar-editor easter-egg contributions into one PR: snake, svelte, rat, giraffe, elephant, sea, wheat, cotton, yinyan, carpathians, snakegame, car, glasses.

Each sprite was pasted verbatim from its issue's ready-to-paste module and validated against `avatars.test.ts` (8×8, `#`/`.` only, unique names). Registry entries in `src/avatars/index.ts` are merged into the existing alphabetical order.