### PR TITLE
fix(claude-code): inject usable tokens, and stop reporting signed-out containers as healthy

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ The app copies your Claude Code credentials and installs the attention hooks int
 
   (The feature installs Node.js if it isn't already present.) Alternatively, install it yourself in your Dockerfile, e.g. `npm install -g @anthropic-ai/claude-code`.
 
+### Sharing one Claude login
+
+Credentials are copied into each container **once, at boot**. That's fine for a token that doesn't change, but OAuth refresh tokens rotate: every refresh mints a new one and invalidates its predecessor. Copying a live login therefore hands the same credential to two `claude` installs, and the first one to refresh silently logs the other out — the container's `claude` blanks its own credentials file and asks you to sign in again, while your host stays signed in (or vice versa). The same applies to two containers seeded from one host login.
+
+To share a login across containers, use a non-rotating token instead:
+
+```sh
+export CODEBAY_CLAUDE_CODE_TOKEN=$(claude setup-token)
+```
+
+or paste it into **Settings → set tokens manually**. Both take precedence over host discovery. Reading the host's keychain / `~/.claude/.credentials.json` still works and stays the zero-config default; just expect to re-create an instance when it drifts.
+
 ## Container injections
 
 After `devcontainer up`, the app installs a few things into each container. Each is a self-contained module under `src/container-injections/` (add or remove one by editing that directory's registry):
@@ -133,6 +145,7 @@ host paths, so put `CODEBAY_DATA_DIR` **under `$HOME`** (e.g. `$HOME/.codebay`);
 - `DOCKER_HOST` — Docker daemon socket/URL to connect to (e.g. `unix://$HOME/.colima/default/docker.sock` or `tcp://1.2.3.4:2375`); defaults to your active Docker context
 - `BASIC_AUTH_PASSWORD` — enables HTTP Basic Auth over the whole UI (disabled when unset)
 - `MOCHI_KEY` — base64url-encoded 32-byte secret; set it for persistent deployments so signed image URLs and island props survive restarts (a random key is generated when unset)
-- `CODEBAY_CLAUDE_CODE_TOKEN` — inject this Claude Code OAuth token into every container instead of discovering the host's credentials (e.g. from `claude setup-token`)
+- `CODEBAY_CLAUDE_CODE_TOKEN` — inject this Claude Code OAuth token into every container instead of discovering the host's credentials (e.g. from `claude setup-token`); recommended, see [Sharing one Claude login](#sharing-one-claude-login)
+- `CODEBAY_CLAUDE_KEYCHAIN_SERVICE` — macOS Keychain service to read Claude Code credentials from (default `Claude Code-credentials`). Set this if your `claude` runs under a custom `CLAUDE_CONFIG_DIR`, which gives its keychain entry a suffix (e.g. `Claude Code-credentials-c5a249db`)
 - `CODEBAY_GITHUB_TOKEN` — inject this GitHub token into every container instead of reading `gh auth token` from the host
 - `DISABLE_OPEN_BROWSER=1` — skip opening the browser on startup

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ To share a login across containers, use a non-rotating token instead:
 export CODEBAY_CLAUDE_CODE_TOKEN=$(claude setup-token)
 ```
 
-or paste it into **Settings → set tokens manually**. Both take precedence over host discovery. Reading the host's keychain / `~/.claude/.credentials.json` still works and stays the zero-config default; just expect to re-create an instance when it drifts.
+or paste it into **Settings → set tokens manually**. Both take precedence over host discovery, and the token is written into the container as a complete credentials record — `claude` ignores a credentials file that carries only an access token, so the surrounding fields are synthesized for you. Reading the host's keychain / `~/.claude/.credentials.json` still works and stays the zero-config default; just expect to re-create an instance when it drifts.
+
+Note that credentials are applied when a container is **created**. Start/Stop only cycle the existing container — after changing a token, use **Restart container** in the IDE header to re-run the injections.
 
 ## Container injections
 

--- a/src/container-injections/claude-code-credentials.ts
+++ b/src/container-injections/claude-code-credentials.ts
@@ -19,6 +19,25 @@ function manualClaudeToken(): string | null {
 }
 
 /**
+ * `claude` reports "Not logged in" for a credentials file carrying only an
+ * `accessToken`, however valid the token — `scopes` is what flips it (checked against
+ * claude 2.1.215; `expiresAt`/`subscriptionType` turn out not to matter). The real
+ * grant lives server-side, so this just mirrors what an interactive login writes.
+ */
+const TOKEN_SCOPES = [
+	'user:file_upload',
+	'user:inference',
+	'user:mcp_servers',
+	'user:profile',
+	'user:sessions:claude_code'
+];
+
+/** The credentials record to inject for a bare token supplied by the user. */
+export function tokenCredentials(accessToken: string): string {
+	return JSON.stringify({ claudeAiOauth: { accessToken, scopes: TOKEN_SCOPES } });
+}
+
+/**
  * Rejects credentials with no access token, and ones that are unrecoverably dead —
  * an unusable snapshot would otherwise get injected verbatim and leave the container
  * looking "logged in" (file present) while `claude` inside it isn't. A merely-stale
@@ -43,17 +62,14 @@ export function isValid(json: string): boolean {
 }
 
 /**
- * Shell test for a *live* credential file at `"$f"` — one that would actually sign
- * `claude` in. A mere existence check isn't enough: when an in-container refresh is
- * rejected (see the shared-lineage caveat in `apply` below), `claude` doesn't delete
- * the file, it rewrites it in place with `accessToken`/`refreshToken` blanked and
- * `expiresAt: 0`. That file is several hundred bytes, so `[ -s ]` reports it as
- * present and the health list shows a green Claude Code row for a signed-out
- * container. Collapsing whitespace first keeps this working whether the file is
- * written compact (what `claude` does today) or pretty-printed.
+ * Shell test for a *live* credential file at `"$f"`. Existence isn't enough: when an
+ * in-container refresh is rejected (see the shared-lineage caveat below), `claude`
+ * blanks the tokens in place rather than deleting the file, leaving several hundred
+ * bytes that `[ -s ]` happily reports as a healthy login. All whitespace is stripped
+ * first so this holds whether the file is written compact or pretty-printed.
  */
 export const LIVE_CREDENTIALS_TEST =
-	'[ -s "$f" ] && tr -d \' \\n\' < "$f" | grep -q \'"accessToken":"[^"]\'';
+	'[ -s "$f" ] && tr -d \'[:space:]\' < "$f" | grep -q \'"accessToken":"[^"]\'';
 
 /**
  * Locate the host's Claude Code OAuth credentials, returning both the JSON string
@@ -64,12 +80,13 @@ async function locateClaudeCredentials(): Promise<{ creds: string; source: strin
 	// A token set in Settings wins, then the env override, then host discovery.
 	const manual = manualClaudeToken();
 	if (manual) {
-		const creds = JSON.stringify({ claudeAiOauth: { accessToken: manual } });
-		return { creds, source: 'Settings — manual token' };
+		return { creds: tokenCredentials(manual), source: 'Settings — manual token' };
 	}
 	if (CLAUDE_CODE_TOKEN) {
-		const creds = JSON.stringify({ claudeAiOauth: { accessToken: CLAUDE_CODE_TOKEN } });
-		return { creds, source: 'CODEBAY_CLAUDE_CODE_TOKEN env var' };
+		return {
+			creds: tokenCredentials(CLAUDE_CODE_TOKEN),
+			source: 'CODEBAY_CLAUDE_CODE_TOKEN env var'
+		};
 	}
 
 	if (process.platform === 'darwin') {
@@ -120,14 +137,11 @@ async function injectClaudeCredentials(
  * authorized without a fresh login. Containers are throwaway, so we copy auth into
  * each one. Skipped (with a log line) when the host has no credentials.
  *
- * Shared-lineage caveat: this is a one-time snapshot taken at boot, and OAuth refresh
- * tokens rotate — each refresh mints a new one and invalidates its predecessor. So a
- * snapshot of a *live* login (the keychain / `.credentials.json` path) hands the same
- * lineage to both the host and the container, and the first one to refresh silently
- * logs the other out. It's the same story between two containers seeded from one host
- * login. A non-rotating token (`claude setup-token` → the Settings manual token or
- * `CODEBAY_CLAUDE_CODE_TOKEN`) is the only way to share one login across several
- * `claude` installs; re-injecting on failure would only reverse who loses.
+ * Shared-lineage caveat: this snapshot is taken once at boot, and OAuth refresh tokens
+ * rotate — each refresh invalidates its predecessor. Snapshotting a *live* login hands
+ * one lineage to two `claude` installs, and whichever refreshes first logs the other
+ * out. Only a non-rotating `claude setup-token` fixes that; re-injecting on failure
+ * would just reverse who loses.
  */
 export const claudeCodeCredentials: Injection = {
 	id: 'claude-code-credentials',

--- a/src/container-injections/claude-code-credentials.ts
+++ b/src/container-injections/claude-code-credentials.ts
@@ -43,6 +43,19 @@ export function isValid(json: string): boolean {
 }
 
 /**
+ * Shell test for a *live* credential file at `"$f"` — one that would actually sign
+ * `claude` in. A mere existence check isn't enough: when an in-container refresh is
+ * rejected (see the shared-lineage caveat in `apply` below), `claude` doesn't delete
+ * the file, it rewrites it in place with `accessToken`/`refreshToken` blanked and
+ * `expiresAt: 0`. That file is several hundred bytes, so `[ -s ]` reports it as
+ * present and the health list shows a green Claude Code row for a signed-out
+ * container. Collapsing whitespace first keeps this working whether the file is
+ * written compact (what `claude` does today) or pretty-printed.
+ */
+export const LIVE_CREDENTIALS_TEST =
+	'[ -s "$f" ] && tr -d \' \\n\' < "$f" | grep -q \'"accessToken":"[^"]\'';
+
+/**
  * Locate the host's Claude Code OAuth credentials, returning both the JSON string
  * and a human-readable description of where it came from, or null if absent.
  * macOS keeps them in the login Keychain; Linux/others use ~/.claude/.credentials.json.
@@ -106,6 +119,15 @@ async function injectClaudeCredentials(
  * Inject the host's Claude Code OAuth credentials so the in-container `claude` is
  * authorized without a fresh login. Containers are throwaway, so we copy auth into
  * each one. Skipped (with a log line) when the host has no credentials.
+ *
+ * Shared-lineage caveat: this is a one-time snapshot taken at boot, and OAuth refresh
+ * tokens rotate — each refresh mints a new one and invalidates its predecessor. So a
+ * snapshot of a *live* login (the keychain / `.credentials.json` path) hands the same
+ * lineage to both the host and the container, and the first one to refresh silently
+ * logs the other out. It's the same story between two containers seeded from one host
+ * login. A non-rotating token (`claude setup-token` → the Settings manual token or
+ * `CODEBAY_CLAUDE_CODE_TOKEN`) is the only way to share one login across several
+ * `claude` installs; re-injecting on failure would only reverse who loses.
  */
 export const claudeCodeCredentials: Injection = {
 	id: 'claude-code-credentials',
@@ -137,8 +159,8 @@ export const claudeCodeCredentials: Injection = {
 	async check(target) {
 		return checkPresence(
 			target,
-			'h=$(eval echo ~$(id -un)); d="${CLAUDE_CONFIG_DIR:-$h/.claude}"; ' +
-				'[ -s "$d/.credentials.json" ] && echo 1 || echo 0'
+			'h=$(eval echo ~$(id -un)); d="${CLAUDE_CONFIG_DIR:-$h/.claude}"; f="$d/.credentials.json"; ' +
+				`if ${LIVE_CREDENTIALS_TEST}; then echo 1; else echo 0; fi`
 		);
 	}
 };

--- a/src/container-injections/injections.isolated.test.ts
+++ b/src/container-injections/injections.isolated.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { injections, resolveInjections } from '../lib/injections.server.ts';
 import { setOption } from '../lib/db.server.ts';
 import { attentionHookSettings } from './attention-hooks.ts';
-import { isValid } from './claude-code-credentials.ts';
+import { isValid, LIVE_CREDENTIALS_TEST } from './claude-code-credentials.ts';
 import { customEndpointConfig } from './claude-code-custom.ts';
 import { ghHostBlock, parseGhHosts } from './github-credentials.ts';
 import { hostEnvVarPresence, hostEnvVarsConfig, parseHostEnvVarNames } from './host-env-vars.ts';
@@ -425,5 +428,60 @@ describe('claude-code-credentials isValid', () => {
 	test('falls back to the access token expiry when there is no refresh-token expiry', () => {
 		expect(isValid(oauth({ expiresAt: Date.now() - 1000 }))).toBe(false);
 		expect(isValid(oauth({ expiresAt: Date.now() + 1000 }))).toBe(true);
+	});
+});
+
+describe('claude-code-credentials LIVE_CREDENTIALS_TEST', () => {
+	/** Run the injection's own shell predicate against a file, exactly as `check()` does. */
+	function isLive(content: string | null): boolean {
+		const dir = mkdtempSync(join(tmpdir(), 'codebay-creds-'));
+		const file = join(dir, '.credentials.json');
+		if (content !== null) writeFileSync(file, content);
+		try {
+			const res = Bun.spawnSync([
+				'bash',
+				'-c',
+				`f="$1"; if ${LIVE_CREDENTIALS_TEST}; then echo 1; else echo 0; fi`,
+				'bash',
+				file
+			]);
+			return res.stdout.toString().trim() === '1';
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	}
+
+	/** The shape `claude` writes; blank tokens are what a rejected refresh leaves behind. */
+	const credsFile = (accessToken: string, spaced = false) =>
+		JSON.stringify(
+			{
+				claudeAiOauth: {
+					accessToken,
+					refreshToken: accessToken ? 'refresh' : '',
+					expiresAt: accessToken ? Date.now() + 1000 : 0,
+					scopes: ['user:inference'],
+					subscriptionType: 'max'
+				}
+			},
+			null,
+			spaced ? 2 : undefined
+		);
+
+	test('accepts a file carrying a real access token', () => {
+		expect(isLive(credsFile('sk-ant-oat-abc'))).toBe(true);
+	});
+
+	test('rejects the blanked file a rejected in-container refresh leaves behind', () => {
+		expect(isLive(credsFile(''))).toBe(false);
+	});
+
+	test('rejects a missing or empty file', () => {
+		expect(isLive(null)).toBe(false);
+		expect(isLive('')).toBe(false);
+	});
+
+	test('reads the same either way when the file is pretty-printed', () => {
+		expect(isLive(credsFile('sk-ant-oat-abc', true))).toBe(true);
+		expect(isLive(credsFile('', true))).toBe(false);
 	});
 });

--- a/src/container-injections/injections.isolated.test.ts
+++ b/src/container-injections/injections.isolated.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { injections, resolveInjections } from '../lib/injections.server.ts';
 import { setOption } from '../lib/db.server.ts';
 import { attentionHookSettings } from './attention-hooks.ts';
-import { isValid, LIVE_CREDENTIALS_TEST } from './claude-code-credentials.ts';
+import { isValid, LIVE_CREDENTIALS_TEST, tokenCredentials } from './claude-code-credentials.ts';
 import { customEndpointConfig } from './claude-code-custom.ts';
 import { ghHostBlock, parseGhHosts } from './github-credentials.ts';
 import { hostEnvVarPresence, hostEnvVarsConfig, parseHostEnvVarNames } from './host-env-vars.ts';
@@ -431,6 +431,27 @@ describe('claude-code-credentials isValid', () => {
 	});
 });
 
+describe('claude-code-credentials tokenCredentials', () => {
+	const parse = (json: string) =>
+		(JSON.parse(json) as { claudeAiOauth: { accessToken: string; scopes?: string[] } })
+			.claudeAiOauth;
+
+	test('carries the token through verbatim', () => {
+		expect(parse(tokenCredentials('sk-ant-oat01-abc')).accessToken).toBe('sk-ant-oat01-abc');
+	});
+
+	// Without `scopes`, `claude` reports "Not logged in" however valid the token is.
+	test('includes scopes, without which claude ignores the credentials', () => {
+		const scopes = parse(tokenCredentials('sk-ant-oat01-abc')).scopes;
+		expect(scopes).toBeDefined();
+		expect(scopes).toContain('user:inference');
+	});
+
+	test('produces a record that passes isValid', () => {
+		expect(isValid(tokenCredentials('sk-ant-oat01-abc'))).toBe(true);
+	});
+});
+
 describe('claude-code-credentials LIVE_CREDENTIALS_TEST', () => {
 	/** Run the injection's own shell predicate against a file, exactly as `check()` does. */
 	function isLive(content: string | null): boolean {
@@ -483,5 +504,17 @@ describe('claude-code-credentials LIVE_CREDENTIALS_TEST', () => {
 	test('reads the same either way when the file is pretty-printed', () => {
 		expect(isLive(credsFile('sk-ant-oat-abc', true))).toBe(true);
 		expect(isLive(credsFile('', true))).toBe(false);
+	});
+
+	test('is unfazed by tabs and CRLF line endings', () => {
+		const crlf = (s: string) => s.replace(/\n/g, '\r\n').replace(/ {2}/g, '\t');
+		expect(isLive(crlf(credsFile('sk-ant-oat-abc', true)))).toBe(true);
+		expect(isLive(crlf(credsFile('', true)))).toBe(false);
+	});
+
+	// Ties the two halves together: whatever `tokenCredentials` injects must be what
+	// the health check then reports as a live login, or a fresh container reads red.
+	test('accepts the record tokenCredentials injects', () => {
+		expect(isLive(tokenCredentials('sk-ant-oat01-abc'))).toBe(true);
 	});
 });


### PR DESCRIPTION
Split out of #52. Independent of the other two — no shared files.

## 1. A bare token was injected without `scopes`

`locateClaudeCredentials()`'s manual-token and `CODEBAY_CLAUDE_CODE_TOKEN` branches both built:

```json
{"claudeAiOauth":{"accessToken":"sk-ant-oat01-…"}}
```

`claude` ignores that. A perfectly valid `claude setup-token` token, injected correctly, mode 600, right path — and the container still reports `Not logged in · Please run /login`.

Bisected against claude 2.1.215 inside a live container:

| fields | result |
|---|---|
| `accessToken` | ❌ Not logged in |
| `accessToken` + `expiresAt` | ❌ Not logged in |
| `accessToken` + `scopes` | ✅ authenticates |
| `accessToken` + `scopes` + `subscriptionType` | ✅ authenticates |

`scopes` is the field that matters; `expiresAt` and `subscriptionType` are irrelevant. Both branches now go through `tokenCredentials()`, which writes the scope list an interactive login produces. Host-discovered credentials were never affected — they carry their own scopes.

This made the README's own recommendation (`CODEBAY_CLAUDE_CODE_TOKEN=$(claude setup-token)`) silently produce a signed-out container.

## 2. Blanked credentials reported as healthy

`check()` only tested `[ -s .credentials.json ]`. When an in-container refresh is rejected, `claude` doesn't delete the file — it rewrites it with the tokens blanked:

```json
{"claudeAiOauth":{"accessToken":"","refreshToken":"","expiresAt":0,…}}
```

~280 bytes, so `[ -s ]` passed and the health list showed a green **Claude Code** row for a signed-out container. Verified on a live instance: old check `1`, new check `0`.

Now requires a non-empty `accessToken`. The predicate is extracted as `LIVE_CREDENTIALS_TEST` so `bash` can exercise it outside a container, and all whitespace is stripped first so it holds for compact, pretty-printed, or tab/CRLF-formatted files.

### Why the file gets blanked

Documented on `apply()` and in the README. Credentials are snapshotted once at boot, but OAuth refresh tokens rotate — each refresh invalidates its predecessor. Snapshotting a *live* login hands one lineage to two `claude` installs and whichever refreshes first logs the other out. Not fixable by re-injecting on failure: that just reverses who loses. Only a non-rotating `setup-token` avoids it — which is what made #1 worth finding.

Also adds `CODEBAY_CLAUDE_KEYCHAIN_SERVICE` to the README env var list; it was undocumented, and a custom `CLAUDE_CONFIG_DIR` suffixes the keychain entry (e.g. `Claude Code-credentials-c5a249db`).

## Tests

Nine tests over `tokenCredentials` and `LIVE_CREDENTIALS_TEST`, including one that runs the real shell predicate against what `tokenCredentials` writes — tying injection output to the health check, which is the invariant that broke here. `bun run checks` passes: 135 tests.

## Note on merge order

The new README section says to use **Restart container** in the IDE header to re-apply a changed token. Once #52's rebuild action lands (split out as a separate PR), that sentence can also mention **Rebuild** on the instance card.

## Not covered

Nothing re-probes credentials on a running container, so the Claude Code row flips red on the next health tick rather than immediately. And `check()` verifies the injection landed, not that the token still authenticates — an expired-but-well-formed token still reads green. Catching that needs a real API call, which felt like the wrong thing to put in a health poll.
