### PR TITLE
feat(dashboard): add a rebuild action to the instance card

### DIFF
--- a/src/components/DashboardView.svelte
+++ b/src/components/DashboardView.svelte
@@ -44,9 +44,7 @@
 	async function act(id: string, action: 'start' | 'stop' | 'delete' | 'rebuild') {
 		actionError = null;
 		if (action === 'delete' && !confirm('Delete this instance and its copied files?')) return;
-		// Rebuild throws the container away and runs `devcontainer up` again. The
-		// workspace copy lives on the host so edits survive, but anything installed
-		// into the container by hand does not — worth a prompt before a long rebuild.
+		// Rebuild discards the container; the workspace copy lives on the host and survives.
 		if (
 			action === 'rebuild' &&
 			!confirm('Recreate this container and re-run setup? The workspace is kept.')

--- a/src/components/DashboardView.svelte
+++ b/src/components/DashboardView.svelte
@@ -41,9 +41,17 @@
 		}
 	}
 
-	async function act(id: string, action: 'start' | 'stop' | 'delete') {
+	async function act(id: string, action: 'start' | 'stop' | 'delete' | 'rebuild') {
 		actionError = null;
 		if (action === 'delete' && !confirm('Delete this instance and its copied files?')) return;
+		// Rebuild throws the container away and runs `devcontainer up` again. The
+		// workspace copy lives on the host so edits survive, but anything installed
+		// into the container by hand does not — worth a prompt before a long rebuild.
+		if (
+			action === 'rebuild' &&
+			!confirm('Recreate this container and re-run setup? The workspace is kept.')
+		)
+			return;
 		try {
 			await apiPost(`/api/instances/${id}/${action}`, undefined, `Failed to ${action}`);
 			// The SSE stream reflects the resulting state.

--- a/src/components/InstanceCard.svelte
+++ b/src/components/InstanceCard.svelte
@@ -18,7 +18,7 @@
 		instance: Instance;
 		editing: boolean;
 		editingName: string;
-		onact: (action: 'start' | 'stop' | 'delete') => void;
+		onact: (action: 'start' | 'stop' | 'delete' | 'rebuild') => void;
 		onstartrename: () => void;
 		oncommitrename: () => void;
 		oncancelrename: () => void;
@@ -70,8 +70,20 @@
 		{#if instance.status === 'running'}
 			<Button variant="primary" size="sm" href={`/ide/${instance.id}`}>Open IDE</Button>
 			<Button size="sm" onclick={() => onact('stop')}>Stop</Button>
+			<!-- Start/Stop only cycle the existing container; rebuild is the one action
+			     that recreates it, and so the only one that re-runs the injections. -->
+			<Button
+				size="sm"
+				title="Recreate the container and re-run setup (credentials, hooks, port forwards)"
+				onclick={() => onact('rebuild')}>Rebuild</Button
+			>
 		{:else if instance.status === 'stopped' || (instance.status === 'error' && instance.container_id)}
 			<Button size="sm" onclick={() => onact('start')}>Start</Button>
+			<Button
+				size="sm"
+				title="Recreate the container and re-run setup (credentials, hooks, port forwards)"
+				onclick={() => onact('rebuild')}>Rebuild</Button
+			>
 		{:else if instance.status === 'creating'}
 			<Button size="sm" href={`/instances/${instance.id}`} target="_blank" rel="noopener noreferrer"
 				>View logs</Button

--- a/src/components/InstanceCard.svelte
+++ b/src/components/InstanceCard.svelte
@@ -23,6 +23,15 @@
 		oncommitrename: () => void;
 		oncancelrename: () => void;
 	} = $props();
+
+	// Start/Stop only cycle the existing container; rebuild is what re-runs the
+	// injections (credentials, hooks, port forwards). Offered wherever there's a
+	// container to replace — never while one is already building.
+	const canRebuild = $derived(
+		instance.status === 'running' ||
+			instance.status === 'stopped' ||
+			(instance.status === 'error' && !!instance.container_id)
+	);
 </script>
 
 <li class="card panel">
@@ -70,23 +79,18 @@
 		{#if instance.status === 'running'}
 			<Button variant="primary" size="sm" href={`/ide/${instance.id}`}>Open IDE</Button>
 			<Button size="sm" onclick={() => onact('stop')}>Stop</Button>
-			<!-- Start/Stop only cycle the existing container; rebuild is the one action
-			     that recreates it, and so the only one that re-runs the injections. -->
-			<Button
-				size="sm"
-				title="Recreate the container and re-run setup (credentials, hooks, port forwards)"
-				onclick={() => onact('rebuild')}>Rebuild</Button
-			>
 		{:else if instance.status === 'stopped' || (instance.status === 'error' && instance.container_id)}
 			<Button size="sm" onclick={() => onact('start')}>Start</Button>
-			<Button
-				size="sm"
-				title="Recreate the container and re-run setup (credentials, hooks, port forwards)"
-				onclick={() => onact('rebuild')}>Rebuild</Button
-			>
 		{:else if instance.status === 'creating'}
 			<Button size="sm" href={`/instances/${instance.id}`} target="_blank" rel="noopener noreferrer"
 				>View logs</Button
+			>
+		{/if}
+		{#if canRebuild}
+			<Button
+				size="sm"
+				title="Recreate the container and re-run setup (credentials, hooks, port forwards)"
+				onclick={() => onact('rebuild')}>Rebuild</Button
 			>
 		{/if}
 		<Button


### PR DESCRIPTION
Split out of #52. Independent of the other two — no shared files.

Rebuild was only reachable from the `/ide/:id` header. Start/Stop merely cycle the existing container; `rebuildInstance` → `devcontainer up --remove-existing-container` is the only path that re-runs injections, so after changing a token there was no way to re-apply it from the dashboard. The `/api/instances/:id/rebuild` route already existed — this surfaces it, behind a confirm.

Offered wherever there's a container to replace (`running`, `stopped`, or `error` with a `container_id`) via a single `canRebuild` derived, and never while one is already building — `rebuildInstance` no-ops on `creating`, so a button there would silently do nothing.

## Follow-up available

Once #53 lands, its "Sharing one Claude login" README section can mention **Rebuild** on the instance card alongside **Restart container** in the IDE header. Left out of both PRs so neither documents a button the other hasn't shipped yet.

## Verification

`bun run checks` passes: 126 tests, 0 type errors.
