### PR TITLE
feat(claude-code): disable co-author byline on commits by default

### DIFF
--- a/src/container-injections/claude-no-coauthor.ts
+++ b/src/container-injections/claude-no-coauthor.ts
@@ -1,0 +1,46 @@
+import { checkPresence, execInContainer } from '../lib/exec.server.ts';
+import { mergeClaudeSettingsScript } from './attention-hooks.ts';
+import type { ContainerTarget, Injection } from '../lib/injections.server.ts';
+
+/**
+ * Merge `includeCoAuthoredBy: false` into the container's Claude config dir.
+ * Reuses the shared jq-merge-with-fallback script (see `attention-hooks.ts`),
+ * so this composes with whatever else has already written to settings.json
+ * regardless of apply order.
+ */
+async function injectNoCoauthor(target: ContainerTarget): Promise<{ ok: boolean; error?: string }> {
+	const res = await execInContainer(target, {
+		script: mergeClaudeSettingsScript(),
+		stdin: JSON.stringify({ includeCoAuthoredBy: false })
+	});
+	return res.ok ? { ok: true } : { ok: false, error: res.error };
+}
+
+/**
+ * Turn off Claude Code's `Co-Authored-By: Claude` commit trailer and
+ * "Generated with Claude Code" line, so commits made from a container look
+ * like the user's own work. Always applied; it has no host dependency — this
+ * is a Codebay-wide default, not an opt-in setting.
+ */
+export const claudeNoCoauthor: Injection = {
+	id: 'claude-no-coauthor',
+	label: 'no co-author byline',
+
+	async apply(target, log) {
+		log('Disabling Claude co-author commit byline…\n');
+		const result = await injectNoCoauthor(target);
+		log(
+			result.ok
+				? '✓ Claude co-author byline disabled\n'
+				: `⚠ Claude co-author byline injection failed: ${result.error}\n`
+		);
+	},
+
+	async check(target) {
+		return checkPresence(
+			target,
+			'h=$(eval echo ~$(id -un)); d="${CLAUDE_CONFIG_DIR:-$h/.claude}"; ' +
+				'[ -s "$d/settings.json" ] && grep -q includeCoAuthoredBy "$d/settings.json" && echo 1 || echo 0'
+		);
+	}
+};

--- a/src/container-injections/injections.isolated.test.ts
+++ b/src/container-injections/injections.isolated.test.ts
@@ -60,6 +60,14 @@ describe('injection registry', () => {
 		expect(aliases!.auth).toBeUndefined();
 	});
 
+	test('claude-no-coauthor is registered with a health check', () => {
+		const noCoauthor = injections.find((i) => i.id === 'claude-no-coauthor');
+		expect(noCoauthor).toBeDefined();
+		expect(typeof noCoauthor!.check).toBe('function');
+		// No host dependency, so no auth chip — this is a Codebay-wide default.
+		expect(noCoauthor!.auth).toBeUndefined();
+	});
+
 	test('claude-statusline is registered with an auth chip and a health check', () => {
 		const statusline = injections.find((i) => i.id === 'claude-statusline');
 		expect(statusline).toBeDefined();

--- a/src/lib/injections.server.ts
+++ b/src/lib/injections.server.ts
@@ -11,6 +11,7 @@ import { attentionHooks } from '../container-injections/attention-hooks.ts';
 import { claudeStatusline } from '../container-injections/claude-statusline.ts';
 import { claudeSkipPermissions } from '../container-injections/claude-skip-permissions.ts';
 import { claudeAliases } from '../container-injections/claude-aliases.ts';
+import { claudeNoCoauthor } from '../container-injections/claude-no-coauthor.ts';
 import { hostEnvVars } from '../container-injections/host-env-vars.ts';
 
 /**
@@ -76,6 +77,7 @@ const BASE_INJECTIONS_TAIL: Injection[] = [
 	claudeStatusline,
 	claudeSkipPermissions,
 	claudeAliases,
+	claudeNoCoauthor,
 	hostEnvVars
 ];
 


### PR DESCRIPTION
## Summary
- Adds a new always-applied container injection, `claude-no-coauthor`, that merges `includeCoAuthoredBy: false` into each container's `~/.claude/settings.json`.
- Reuses the existing `mergeClaudeSettingsScript()` jq-merge helper so it composes with the attention-hooks and statusLine injections regardless of apply order.
- Wires it into `BASE_INJECTIONS_TAIL` in `src/lib/injections.server.ts`, which covers boot, health probing, and the setup-UI auth chips in one edit.

With this, Claude Code commits made inside Codebay instances no longer carry the `Co-Authored-By: Claude` trailer or the "Generated with Claude Code" line.

## Test plan
- [x] `bun run checks` (format + typecheck + tests) passes, including a new registry test asserting `claude-no-coauthor` is registered with a health check and no auth chip.