### PR TITLE
feat(cli): add --help and --version flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ## [0.2.1](https://github.com/khromov/codebay/compare/codebay-v0.2.0...codebay-v0.2.1) (2026-07-30)
 
-
 ### Bug Fixes
 
-* publish forwarded ports on HOST, show version, stabilize avatar hint ([#59](https://github.com/khromov/codebay/issues/59)) ([aa50799](https://github.com/khromov/codebay/commit/aa507994ab970d9af01c7e02dc3732aa0d8d52ba))
+- publish forwarded ports on HOST, show version, stabilize avatar hint ([#59](https://github.com/khromov/codebay/issues/59)) ([aa50799](https://github.com/khromov/codebay/commit/aa507994ab970d9af01c7e02dc3732aa0d8d52ba))
 
 ## [0.2.0](https://github.com/khromov/codebay/compare/codebay-v0.1.0...codebay-v0.2.0) (2026-07-29)
 

--- a/bin/codebay.ts
+++ b/bin/codebay.ts
@@ -3,12 +3,53 @@
 // ./public, and the .mochi manifest relative to process.cwd(), so chdir into the
 // package root before booting. Dynamic import() of a relative specifier resolves
 // against this module's URL (not cwd), so the chdir doesn't affect it.
+import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 
 if (typeof Bun === 'undefined') {
 	console.error('codebay requires Bun — run it with `bunx codebay` (https://bun.sh).');
 	process.exit(1);
+}
+
+const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function readVersion(): string {
+	try {
+		return JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf8')).version ?? 'unknown';
+	} catch {
+		return 'unknown';
+	}
+}
+
+const args = process.argv.slice(2);
+
+if (args.includes('--version') || args.includes('-v')) {
+	console.log(readVersion());
+	process.exit(0);
+}
+
+if (args.includes('--help') || args.includes('-h')) {
+	console.log(`codebay ${readVersion()} — spin up isolated devcontainers with a browser IDE.
+
+Usage: bunx codebay [options]
+
+Starts the web UI (default http://localhost:6969) and opens it in your browser.
+
+Options:
+  -h, --help       Show this help and exit
+  -v, --version    Print the version and exit
+
+Environment variables:
+  PORT                       Server port (default 6969)
+  DATA_DIR                   Where state lives (default ~/.codebay)
+  DOCKER_HOST                Docker socket/URL (defaults to your active Docker context)
+  HOST                       Bind address (default 127.0.0.1; set 0.0.0.0 for LAN access)
+  BASIC_AUTH_PASSWORD        Enable HTTP Basic Auth over the whole UI (required for 0.0.0.0)
+  CODEBAY_CLAUDE_CODE_TOKEN  Claude Code token to inject into every container
+  CODEBAY_GITHUB_TOKEN       GitHub token to inject into every container
+  DISABLE_OPEN_BROWSER=1     Skip opening the browser on startup`);
+	process.exit(0);
 }
 
 // config.server.ts resolves a relative DATA_DIR against process.cwd(). Pin it to the
@@ -18,5 +59,5 @@ if (process.env.DATA_DIR && !isAbsolute(process.env.DATA_DIR)) {
 	process.env.DATA_DIR = resolve(process.cwd(), process.env.DATA_DIR);
 }
 
-process.chdir(join(dirname(fileURLToPath(import.meta.url)), '..'));
+process.chdir(pkgRoot);
 await import('../src/index.ts');


### PR DESCRIPTION
## What

`bunx codebay --help` (and `-h`) now prints a short usage summary plus the env vars that control codebay, then exits — instead of unconditionally booting the server. Also adds `--version` / `-v`.

## Why

There was no way to discover how to configure codebay without reading the README.

## Details

- Flag handling lives in `bin/codebay.ts` and runs **before** any side effects (the `DATA_DIR` absolutize, `chdir`, and `import('../src/index.ts')`), so `--help`/`--version` are instant and never boot the server.
- Env var list mirrors README's canonical Configuration section.
- No args → boots normally as before.

## Verification

- `bun bin/codebay.ts --help` / `-h` / `--version` / `-v` → print and exit 0, no server boot
- `bun run checks` → format + typecheck + 138 tests all green