### PR TITLE
docs: note harmless svelte peer-dependency warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ The UI opens at `http://localhost:6969`. State (SQLite DB + per-instance workspa
 - `CODEBAY_GITHUB_TOKEN` — GitHub token to inject instead of reading `gh auth token` from the host
 - `DISABLE_OPEN_BROWSER=1` — skip opening the browser on startup
 
+## Troubleshooting
+
+- `warn: incorrect peer dependency "svelte@5.56.8"` on startup — harmless. It comes from `svelte-french-toast`, whose published peer range predates Svelte 5; the library works correctly on Svelte 5. Nothing to fix.
+
 ## Development
 
 ```sh


### PR DESCRIPTION
## What

Documents the `warn: incorrect peer dependency "svelte@5.56.8"` message users see on `bunx codebay@latest`.

## Why

The warning comes from `svelte-french-toast@1.2.0`, whose published `peerDependencies` is `svelte: ^3.57.0 || ^4.0.0` — it predates Svelte 5, so Bun flags the installed `svelte@5.56.8` as out of range. The library works fine on Svelte 5; the warning is purely a stale declared range. It's *not* `mochi-framework` (peer `^5.56.6`, satisfied).

It can't be silenced for `bunx` end users via `resolutions`/`overrides` (version, not peer-range) or `patchedDependencies` (only applies when codebay is the root project). So we document it as harmless rather than migrating off the library.

## Change

One `## Troubleshooting` entry in `README.md`.