### PR TITLE
feat: allow overriding git identity in settings

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -94,7 +94,7 @@
 
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
 
-    "@lucide/svelte": ["@lucide/svelte@1.27.0", "", { "peerDependencies": { "svelte": "^5" } }, "sha512-qzNBHdqy/MKp2qxuy/DcYELuep6h19fjo+4ech8fZsS4GtZeBtg5jgCTRQvLvwhppt0mhRN6qt8Nt8rPb/J4Ag=="],
+    "@lucide/svelte": ["@lucide/svelte@1.28.0", "", { "peerDependencies": { "svelte": "^5" } }, "sha512-C1Ge84KW2z4q44/WDIEo/2KC2jby5u6mSlta7q+p6g7u0ld8sC/w1fMBiSswF+4bxAl9jlzzaVTpp79qqkiy5g=="],
 
     "@noble/ciphers": ["@noble/ciphers@2.2.0", "", {}, "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA=="],
 
@@ -336,7 +336,7 @@
 
     "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
 
-    "mochi-framework": ["mochi-framework@0.9.0", "", { "dependencies": { "@css-inline/css-inline-wasm": "^0.21.0", "@joint-ops/hitlimit-bun": "1.5.0", "@noble/ciphers": "2.2.0", "@noble/hashes": "2.2.0", "bunqueue": "^2.8.44", "chokidar": "^5.0.0", "deepmerge": "^4.3.1", "devalue": "^5.8.2", "html-entities": "^2.6.0", "ipaddr.js": "2.4.0", "magic-string": "^1.0.0", "mitt": "^3.0.1", "negotiator": "^1.0.0", "nodemailer": "^9.0.3", "svelte-shaker": ">=0.18.1", "zimmerframe": "^1.1.4" }, "peerDependencies": { "@mochi-framework/rsvelte": ">=0.0.1", "@tailwindcss/node": "^4.3.0", "@tailwindcss/oxide": "^4.3.0", "svelte": "^5.56.6" }, "optionalPeers": ["@mochi-framework/rsvelte", "@tailwindcss/node", "@tailwindcss/oxide"], "bin": { "mochi-framework": "src/cli/cli.js" } }, "sha512-hzY5AqRjdi19I21CWhY7IRKPvvaGvV5NLlMC5GNcbkJ57Le5LGTbQQ888bfXOcIbBZl24V3coa3ojJGqCc7bXQ=="],
+    "mochi-framework": ["mochi-framework@0.9.1", "", { "dependencies": { "@css-inline/css-inline-wasm": "^0.21.0", "@joint-ops/hitlimit-bun": "1.5.0", "@noble/ciphers": "2.2.0", "@noble/hashes": "2.2.0", "bunqueue": "^2.8.44", "chokidar": "^5.0.0", "deepmerge": "^4.3.1", "devalue": "^5.8.2", "html-entities": "^2.6.0", "ipaddr.js": "2.4.0", "magic-string": "^1.0.0", "mitt": "^3.0.1", "negotiator": "^1.0.0", "nodemailer": "^9.0.3", "svelte-shaker": ">=0.18.1", "zimmerframe": "^1.1.4" }, "peerDependencies": { "@mochi-framework/rsvelte": ">=0.0.1", "@tailwindcss/node": "^4.3.0", "@tailwindcss/oxide": "^4.3.0", "svelte": "^5.56.6" }, "optionalPeers": ["@mochi-framework/rsvelte", "@tailwindcss/node", "@tailwindcss/oxide"], "bin": { "mochi-framework": "src/cli/cli.js" } }, "sha512-bw1khr5FXPqC4Cf23IdjNYBoMTUClZ5KGtjMTgCdedldHF4HVXIaUKvEHXt6cTewAauVFTg1CoI/NHh0QrA5BA=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 

--- a/package.json
+++ b/package.json
@@ -60,12 +60,12 @@
 	},
 	"dependencies": {
 		"@devcontainers/cli": "^0.88.0",
-		"@fontsource-variable/doto": "^5.2.10",
-		"@fontsource-variable/jetbrains-mono": "^5.2.8",
-		"@lucide/svelte": "^1.27.0",
+		"@fontsource-variable/doto": "^5.3.0",
+		"@fontsource-variable/jetbrains-mono": "^5.3.0",
+		"@lucide/svelte": "^1.28.0",
 		"@zihaolam/bun-sqlite-migrations": "^1.0.3",
 		"dockerode": "^5.0.1",
-		"mochi-framework": "^0.9.0",
+		"mochi-framework": "^0.9.1",
 		"svelte": "^5.56.8",
 		"svelte-french-toast": "^1.2.0"
 	},
@@ -74,13 +74,13 @@
 		"@types/bun": "1.3.14",
 		"@types/dockerode": "^4.0.1",
 		"eslint": "^10.8.0",
-		"eslint-plugin-svelte": "^3.20.0",
+		"eslint-plugin-svelte": "^3.22.0",
 		"globals": "^17.8.0",
-		"prettier": "^3.9.4",
+		"prettier": "^3.9.6",
 		"prettier-plugin-svelte": "^4.1.1",
 		"svelte-check": "4.7.4",
 		"typescript": "^6.0.3",
-		"typescript-eslint": "^8.62.1"
+		"typescript-eslint": "^8.65.0"
 	},
 	"resolutions": {
 		"msgpackr-extract": "npm:@mochi-framework/msgpackr-extract-stub@*",

--- a/src/components/SettingsView.svelte
+++ b/src/components/SettingsView.svelte
@@ -33,6 +33,7 @@
 		disableBuildCache,
 		copyIgnorePatterns,
 		builtinCopyIgnore,
+		gitIdentityEnabled,
 		gitIdentityName,
 		gitIdentityEmail,
 		dockerArch,
@@ -57,6 +58,7 @@
 		disableBuildCache: boolean;
 		copyIgnorePatterns: string;
 		builtinCopyIgnore: string;
+		gitIdentityEnabled: boolean;
 		gitIdentityName: string;
 		gitIdentityEmail: string;
 		dockerArch: string | null;
@@ -190,6 +192,17 @@
 		flushSync(() => (copyIgnore = builtinCopyIgnore));
 		copyIgnoreFormEl?.requestSubmit();
 	}
+
+	// svelte-ignore state_referenced_locally
+	let gitIdentity = $state(gitIdentityEnabled);
+	let savingGitToggle = $state(false);
+	let gitToggleError = $state<string | null>(null);
+
+	const gitIdentityToggleOpts = toggleOpts({
+		set: (v) => (gitIdentity = v),
+		setSaving: (v) => (savingGitToggle = v),
+		setError: (v) => (gitToggleError = v)
+	});
 
 	// Both fields must be saved together — a lone name or email doesn't count as an override.
 	// svelte-ignore state_referenced_locally
@@ -499,7 +512,7 @@
 				{@attach enhance(imageOpts)}
 			>
 				<div class="label">
-					<Container size={18} />
+					<Container size={20} />
 					<div class="text">
 						<div class="name">
 							Default container image
@@ -560,7 +573,7 @@
 				{@attach enhance(copyIgnoreOpts)}
 			>
 				<div class="label">
-					<FolderMinus size={18} />
+					<FolderMinus size={20} />
 					<div class="text">
 						<div class="name">Skip when copying a local folder</div>
 						<div class="desc">
@@ -601,59 +614,94 @@
 
 		<section class="card">
 			<form
-				class="row divided token-row"
+				class="row"
 				method="POST"
-				action="?/gitIdentityOverride"
-				{@attach enhance(gitIdentityOpts)}
+				action="?/gitIdentityToggle"
+				{@attach enhance(gitIdentityToggleOpts)}
 			>
 				<div class="label">
-					<UserCog size={18} />
+					<UserCog size={20} />
 					<div class="text">
-						<div class="name">Git identity</div>
+						<div class="name">Override git identity</div>
 						<div class="desc">
-							Name and email injected as <code>git config --global user.name/user.email</code> in every
-							new container. When both are set here, they always take precedence over the host's own git
-							config. Leave either blank to fall back to the host's identity.
+							Inject a name and email as <code>git config --global user.name/user.email</code> in every
+							new container, taking precedence over the host's own git config. When off, each container
+							falls back to the host's identity.
 						</div>
 					</div>
 				</div>
-				<div class="model-fields">
-					<label class="model-row">
-						<span class="model-label">Name</span>
-						<input
-							type="text"
-							name="name"
-							class="image-input"
-							bind:value={gitName}
-							spellcheck="false"
-							autocapitalize="off"
-							autocorrect="off"
-							placeholder="Jane Doe"
-						/>
-					</label>
-					<label class="model-row">
-						<span class="model-label">Email</span>
-						<input
-							type="text"
-							name="email"
-							class="image-input"
-							bind:value={gitEmail}
-							spellcheck="false"
-							autocapitalize="off"
-							autocorrect="off"
-							placeholder="jane@example.com"
-						/>
-					</label>
-					<div class="model-save-row">
-						<Button type="submit" disabled={savingGitIdentity}>Save</Button>
-					</div>
-				</div>
-				{#if gitIdentityError}
-					<div class="msg error">{gitIdentityError}</div>
-				{:else if gitIdentitySaved}
-					<div class="msg ok">Saved.</div>
-				{/if}
+				<label class="switch">
+					<input
+						type="checkbox"
+						name="enabled"
+						checked={gitIdentity}
+						disabled={savingGitToggle}
+						onchange={(e) => {
+							gitIdentity = e.currentTarget.checked;
+							e.currentTarget.form?.requestSubmit();
+						}}
+					/>
+					<span class="track"><span class="thumb"></span></span>
+				</label>
 			</form>
+			{#if gitToggleError}
+				<div class="sub"><div class="msg error">{gitToggleError}</div></div>
+			{/if}
+
+			{#if gitIdentity}
+				<form
+					class="row divided token-row"
+					method="POST"
+					action="?/gitIdentityOverride"
+					{@attach enhance(gitIdentityOpts)}
+				>
+					<div class="label">
+						<div class="text">
+							<div class="name">Identity</div>
+							<div class="desc">
+								Both fields are required — leave either blank and the container falls back to the
+								host's identity.
+							</div>
+						</div>
+					</div>
+					<div class="model-fields">
+						<label class="model-row">
+							<span class="model-label">Name</span>
+							<input
+								type="text"
+								name="name"
+								class="image-input"
+								bind:value={gitName}
+								spellcheck="false"
+								autocapitalize="off"
+								autocorrect="off"
+								placeholder="Jane Doe"
+							/>
+						</label>
+						<label class="model-row">
+							<span class="model-label">Email</span>
+							<input
+								type="text"
+								name="email"
+								class="image-input"
+								bind:value={gitEmail}
+								spellcheck="false"
+								autocapitalize="off"
+								autocorrect="off"
+								placeholder="jane@example.com"
+							/>
+						</label>
+						<div class="model-save-row">
+							<Button type="submit" disabled={savingGitIdentity}>Save</Button>
+						</div>
+					</div>
+					{#if gitIdentityError}
+						<div class="msg error">{gitIdentityError}</div>
+					{:else if gitIdentitySaved}
+						<div class="msg ok">Saved.</div>
+					{/if}
+				</form>
+			{/if}
 		</section>
 
 		<section class="card">
@@ -664,7 +712,7 @@
 				{@attach enhance(buildCacheToggleOpts)}
 			>
 				<div class="label">
-					<Layers size={18} />
+					<Layers size={20} />
 					<div class="text">
 						<div class="name">Disable build cache</div>
 						<div class="desc">
@@ -698,7 +746,7 @@
 				{@attach enhance(clearCacheOpts)}
 			>
 				<div class="label">
-					<Trash2 size={18} />
+					<Trash2 size={20} />
 					<div class="text">
 						<div class="name">Clear build cache</div>
 						<div class="desc">
@@ -724,7 +772,7 @@
 				{@attach enhance(rebuildAllOpts)}
 			>
 				<div class="label">
-					<Hammer size={18} />
+					<Hammer size={20} />
 					<div class="text">
 						<div class="name">Rebuild running containers (no cache)</div>
 						<div class="desc">
@@ -752,7 +800,7 @@
 				{@attach enhance(manualTokensToggleOpts)}
 			>
 				<div class="label">
-					<KeyRound size={18} />
+					<KeyRound size={20} />
 					<div class="text">
 						<div class="name">
 							Set tokens manually
@@ -881,7 +929,7 @@
 				{@attach enhance(customEndpointToggleOpts)}
 			>
 				<div class="label">
-					<KeyRound size={18} />
+					<KeyRound size={20} />
 					<div class="text">
 						<div class="name">
 							LiteLLM + Bedrock
@@ -1095,7 +1143,7 @@
 				{@attach enhance(hostEnvVarsToggleOpts)}
 			>
 				<div class="label">
-					<Variable size={18} />
+					<Variable size={20} />
 					<div class="text">
 						<div class="name">Host environment variables</div>
 						<div class="desc">
@@ -1193,7 +1241,7 @@
 		<section class="card">
 			<div class="row">
 				<div class="label">
-					<SunMoon size={18} />
+					<SunMoon size={20} />
 					<div class="text">
 						<div class="name">Theme</div>
 						<div class="desc">
@@ -1208,7 +1256,7 @@
 		<section class="card">
 			<div class="row">
 				<div class="label">
-					<Volume2 size={18} />
+					<Volume2 size={20} />
 					<div class="text">
 						<div class="name">Attention sound</div>
 						<div class="desc">
@@ -1230,7 +1278,7 @@
 		<section class="card danger-card">
 			<form class="row" method="POST" action="?/shutdown" {@attach enhance(shutdownOpts)}>
 				<div class="label">
-					<Power size={18} />
+					<Power size={20} />
 					<div class="text">
 						<div class="name">Delete database, containers, and shut down</div>
 						<div class="desc">
@@ -1351,6 +1399,10 @@
 		gap: 12px;
 		color: var(--ink);
 		min-width: 0;
+	}
+	/* Keep the leading icon at its intrinsic size; the flex row would otherwise shrink busier glyphs below 18px. */
+	.label > :global(svg) {
+		flex: none;
 	}
 	.text {
 		min-width: 0;

--- a/src/components/SettingsView.svelte
+++ b/src/components/SettingsView.svelte
@@ -11,6 +11,7 @@
 	import Trash2 from '@lucide/svelte/icons/trash-2';
 	import Hammer from '@lucide/svelte/icons/hammer';
 	import KeyRound from '@lucide/svelte/icons/key-round';
+	import UserCog from '@lucide/svelte/icons/user-cog';
 	import Variable from '@lucide/svelte/icons/variable';
 	import Plus from '@lucide/svelte/icons/plus';
 	import X from '@lucide/svelte/icons/x';
@@ -32,6 +33,8 @@
 		disableBuildCache,
 		copyIgnorePatterns,
 		builtinCopyIgnore,
+		gitIdentityName,
+		gitIdentityEmail,
 		dockerArch,
 		manualTokensEnabled,
 		githubTokenSet,
@@ -54,6 +57,8 @@
 		disableBuildCache: boolean;
 		copyIgnorePatterns: string;
 		builtinCopyIgnore: string;
+		gitIdentityName: string;
+		gitIdentityEmail: string;
 		dockerArch: string | null;
 		manualTokensEnabled: boolean;
 		githubTokenSet: boolean;
@@ -185,6 +190,26 @@
 		flushSync(() => (copyIgnore = builtinCopyIgnore));
 		copyIgnoreFormEl?.requestSubmit();
 	}
+
+	// Both fields must be saved together — a lone name or email doesn't count as an override.
+	// svelte-ignore state_referenced_locally
+	let gitName = $state(gitIdentityName);
+	// svelte-ignore state_referenced_locally
+	let gitEmail = $state(gitIdentityEmail);
+	let savingGitIdentity = $state(false);
+	let gitIdentityError = $state<string | null>(null);
+	let gitIdentitySaved = $state(false);
+
+	const gitIdentityOpts = saveOpts<{ name: string; email: string }>({
+		setSaving: (v) => (savingGitIdentity = v),
+		setError: (v) => (gitIdentityError = v),
+		setMsg: (v) => (gitIdentitySaved = !!v),
+		onSuccess: (data) => {
+			gitName = data?.name ?? gitName;
+			gitEmail = data?.email ?? gitEmail;
+			gitIdentitySaved = true;
+		}
+	});
 
 	// DB-backed rather than localStorage, so it initializes from the prop.
 	// svelte-ignore state_referenced_locally
@@ -569,6 +594,63 @@
 				{#if copyIgnoreError}
 					<div class="msg error">{copyIgnoreError}</div>
 				{:else if copyIgnoreSaved}
+					<div class="msg ok">Saved.</div>
+				{/if}
+			</form>
+		</section>
+
+		<section class="card">
+			<form
+				class="row divided token-row"
+				method="POST"
+				action="?/gitIdentityOverride"
+				{@attach enhance(gitIdentityOpts)}
+			>
+				<div class="label">
+					<UserCog size={18} />
+					<div class="text">
+						<div class="name">Git identity</div>
+						<div class="desc">
+							Name and email injected as <code>git config --global user.name/user.email</code> in every
+							new container. When both are set here, they always take precedence over the host's own git
+							config. Leave either blank to fall back to the host's identity.
+						</div>
+					</div>
+				</div>
+				<div class="model-fields">
+					<label class="model-row">
+						<span class="model-label">Name</span>
+						<input
+							type="text"
+							name="name"
+							class="image-input"
+							bind:value={gitName}
+							spellcheck="false"
+							autocapitalize="off"
+							autocorrect="off"
+							placeholder="Jane Doe"
+						/>
+					</label>
+					<label class="model-row">
+						<span class="model-label">Email</span>
+						<input
+							type="text"
+							name="email"
+							class="image-input"
+							bind:value={gitEmail}
+							spellcheck="false"
+							autocapitalize="off"
+							autocorrect="off"
+							placeholder="jane@example.com"
+						/>
+					</label>
+					<div class="model-save-row">
+						<Button type="submit" disabled={savingGitIdentity}>Save</Button>
+					</div>
+				</div>
+				{#if gitIdentityError}
+					<div class="msg error">{gitIdentityError}</div>
+				{:else if gitIdentitySaved}
 					<div class="msg ok">Saved.</div>
 				{/if}
 			</form>

--- a/src/container-injections/git-identity.ts
+++ b/src/container-injections/git-identity.ts
@@ -1,5 +1,6 @@
 import { checkPresence, execInContainer } from '../lib/exec.server.ts';
 import { spawnCapture } from '../lib/spawn.server.ts';
+import { getOption } from '../lib/db.server.ts';
 import type { Injection } from '../lib/injections.server.ts';
 
 interface GitIdentity {
@@ -11,8 +12,17 @@ function readGitConfig(key: string): Promise<string | null> {
 	return spawnCapture(['git', 'config', '--global', '--get', key]);
 }
 
-/** `--global` so this reads the host user's identity, not the manager checkout's override. */
-async function readGitIdentity(): Promise<GitIdentity | null> {
+/** Both fields are required together — a lone name or email is treated as not configured. */
+function overrideIdentity(): GitIdentity | null {
+	const name = getOption('git_identity_name')?.trim() || '';
+	const email = getOption('git_identity_email')?.trim() || '';
+	return name && email ? { name, email } : null;
+}
+
+/** `--global` so the host fallback reads the host user's identity, not the manager checkout's. */
+export async function readGitIdentity(): Promise<GitIdentity | null> {
+	const override = overrideIdentity();
+	if (override) return override;
 	const [name, email] = await Promise.all([
 		readGitConfig('user.name'),
 		readGitConfig('user.email')
@@ -30,7 +40,12 @@ export const gitIdentity: Injection = {
 		async status() {
 			const identity = await readGitIdentity();
 			return identity
-				? { available: true, source: `git config — ${identity.name}` }
+				? {
+						available: true,
+						source: overrideIdentity()
+							? `Settings override — ${identity.name}`
+							: `git config — ${identity.name}`
+					}
 				: { available: false, source: null };
 		}
 	},

--- a/src/container-injections/git-identity.ts
+++ b/src/container-injections/git-identity.ts
@@ -12,8 +12,20 @@ function readGitConfig(key: string): Promise<string | null> {
 	return spawnCapture(['git', 'config', '--global', '--get', key]);
 }
 
+/**
+ * The toggle is the source of truth, but predates the option: an unset value falls
+ * back to "on when both fields are already filled" so existing overrides keep working.
+ */
+export function gitIdentityEnabled(): boolean {
+	const explicit = getOption('git_identity_enabled');
+	if (explicit === '1') return true;
+	if (explicit === '0') return false;
+	return !!(getOption('git_identity_name')?.trim() && getOption('git_identity_email')?.trim());
+}
+
 /** Both fields are required together — a lone name or email is treated as not configured. */
 function overrideIdentity(): GitIdentity | null {
+	if (!gitIdentityEnabled()) return null;
 	const name = getOption('git_identity_name')?.trim() || '';
 	const email = getOption('git_identity_email')?.trim() || '';
 	return name && email ? { name, email } : null;

--- a/src/container-injections/injections.isolated.test.ts
+++ b/src/container-injections/injections.isolated.test.ts
@@ -7,6 +7,7 @@ import { setOption } from '../lib/db.server.ts';
 import { attentionHookSettings } from './attention-hooks.ts';
 import { isValid, LIVE_CREDENTIALS_TEST, tokenCredentials } from './claude-code-credentials.ts';
 import { customEndpointConfig } from './claude-code-custom.ts';
+import { gitIdentity, readGitIdentity } from './git-identity.ts';
 import { ghHostBlock, parseGhHosts } from './github-credentials.ts';
 import { hostEnvVarPresence, hostEnvVarsConfig, parseHostEnvVarNames } from './host-env-vars.ts';
 import { extractScriptPath } from './claude-statusline.ts';
@@ -237,6 +238,51 @@ describe('customEndpointConfig', () => {
 		const config = customEndpointConfig()!;
 		expect(config.opusModel).toBe('my-custom-opus');
 		setOption('custom_endpoint_opus_model', ''); // cleanup
+	});
+});
+
+describe('git identity override', () => {
+	beforeEach(() => {
+		setOption('git_identity_name', '');
+		setOption('git_identity_email', '');
+	});
+
+	afterEach(() => {
+		setOption('git_identity_name', '');
+		setOption('git_identity_email', '');
+	});
+
+	test('wins over host git config when both name and email are set', async () => {
+		setOption('git_identity_name', 'Jane Doe');
+		setOption('git_identity_email', 'jane@example.com');
+		const identity = await readGitIdentity();
+		expect(identity).toEqual({ name: 'Jane Doe', email: 'jane@example.com' });
+	});
+
+	test('a lone name with no email is not treated as an override', async () => {
+		setOption('git_identity_name', 'Jane Doe');
+		const identity = await readGitIdentity();
+		expect(identity?.name).not.toBe('Jane Doe');
+	});
+
+	test('a lone email with no name is not treated as an override', async () => {
+		setOption('git_identity_email', 'jane@example.com');
+		const identity = await readGitIdentity();
+		expect(identity?.email).not.toBe('jane@example.com');
+	});
+
+	test('blank strings are treated the same as unset', async () => {
+		setOption('git_identity_name', '  ');
+		setOption('git_identity_email', '  ');
+		const identity = await readGitIdentity();
+		expect(identity?.name).not.toBe('  ');
+	});
+
+	test('auth.status() reports the Settings override as the source', async () => {
+		setOption('git_identity_name', 'Jane Doe');
+		setOption('git_identity_email', 'jane@example.com');
+		const status = await gitIdentity.auth!.status();
+		expect(status).toEqual({ available: true, source: 'Settings override — Jane Doe' });
 	});
 });
 

--- a/src/container-injections/injections.isolated.test.ts
+++ b/src/container-injections/injections.isolated.test.ts
@@ -7,7 +7,7 @@ import { setOption } from '../lib/db.server.ts';
 import { attentionHookSettings } from './attention-hooks.ts';
 import { isValid, LIVE_CREDENTIALS_TEST, tokenCredentials } from './claude-code-credentials.ts';
 import { customEndpointConfig } from './claude-code-custom.ts';
-import { gitIdentity, readGitIdentity } from './git-identity.ts';
+import { gitIdentity, gitIdentityEnabled, readGitIdentity } from './git-identity.ts';
 import { ghHostBlock, parseGhHosts } from './github-credentials.ts';
 import { hostEnvVarPresence, hostEnvVarsConfig, parseHostEnvVarNames } from './host-env-vars.ts';
 import { extractScriptPath } from './claude-statusline.ts';
@@ -243,11 +243,13 @@ describe('customEndpointConfig', () => {
 
 describe('git identity override', () => {
 	beforeEach(() => {
+		setOption('git_identity_enabled', '');
 		setOption('git_identity_name', '');
 		setOption('git_identity_email', '');
 	});
 
 	afterEach(() => {
+		setOption('git_identity_enabled', '');
 		setOption('git_identity_name', '');
 		setOption('git_identity_email', '');
 	});
@@ -257,6 +259,21 @@ describe('git identity override', () => {
 		setOption('git_identity_email', 'jane@example.com');
 		const identity = await readGitIdentity();
 		expect(identity).toEqual({ name: 'Jane Doe', email: 'jane@example.com' });
+	});
+
+	test('an explicit off toggle falls back to the host even with both fields set', async () => {
+		setOption('git_identity_enabled', '0');
+		setOption('git_identity_name', 'Jane Doe');
+		setOption('git_identity_email', 'jane@example.com');
+		expect(gitIdentityEnabled()).toBe(false);
+		const identity = await readGitIdentity();
+		expect(identity?.name).not.toBe('Jane Doe');
+	});
+
+	test('the toggle defaults on when both fields are already filled', () => {
+		setOption('git_identity_name', 'Jane Doe');
+		setOption('git_identity_email', 'jane@example.com');
+		expect(gitIdentityEnabled()).toBe(true);
 	});
 
 	test('a lone name with no email is not treated as an override', async () => {

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -9,6 +9,8 @@
 		disableBuildCache,
 		copyIgnorePatterns,
 		builtinCopyIgnore,
+		gitIdentityName,
+		gitIdentityEmail,
 		dockerArch,
 		manualTokensEnabled,
 		githubTokenSet,
@@ -31,6 +33,8 @@
 		disableBuildCache: boolean;
 		copyIgnorePatterns: string;
 		builtinCopyIgnore: string;
+		gitIdentityName: string;
+		gitIdentityEmail: string;
 		dockerArch: string | null;
 		manualTokensEnabled: boolean;
 		githubTokenSet: boolean;
@@ -56,6 +60,8 @@
 	{disableBuildCache}
 	{copyIgnorePatterns}
 	{builtinCopyIgnore}
+	{gitIdentityName}
+	{gitIdentityEmail}
 	{dockerArch}
 	{manualTokensEnabled}
 	{githubTokenSet}

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -9,6 +9,7 @@
 		disableBuildCache,
 		copyIgnorePatterns,
 		builtinCopyIgnore,
+		gitIdentityEnabled,
 		gitIdentityName,
 		gitIdentityEmail,
 		dockerArch,
@@ -33,6 +34,7 @@
 		disableBuildCache: boolean;
 		copyIgnorePatterns: string;
 		builtinCopyIgnore: string;
+		gitIdentityEnabled: boolean;
 		gitIdentityName: string;
 		gitIdentityEmail: string;
 		dockerArch: string | null;
@@ -60,6 +62,7 @@
 	{disableBuildCache}
 	{copyIgnorePatterns}
 	{builtinCopyIgnore}
+	{gitIdentityEnabled}
 	{gitIdentityName}
 	{gitIdentityEmail}
 	{dockerArch}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -164,6 +164,10 @@ export const routes: Record<string, MochiRouteValue> = {
 				// An explicit empty string (as opposed to unset) means "copy everything".
 				copyIgnorePatterns: getOption('copy_ignore_patterns') ?? DEFAULT_COPY_IGNORE,
 				builtinCopyIgnore: DEFAULT_COPY_IGNORE,
+				// Not secrets, so the actual values (not just a "set" flag) go to the client.
+				// Blank means "no override" — fall back to the host's git config.
+				gitIdentityName: getOption('git_identity_name') ?? '',
+				gitIdentityEmail: getOption('git_identity_email') ?? '',
 				dockerArch: await dockerArch(),
 				// Only whether each token is set — the page renders a placeholder from that.
 				manualTokensEnabled: getOption('manual_tokens_enabled') === '1',
@@ -208,6 +212,15 @@ export const routes: Record<string, MochiRouteValue> = {
 				const patterns = str(formData, 'patterns');
 				setOption('copy_ignore_patterns', patterns);
 				return success({ patterns });
+			},
+
+			// Both fields must be saved together — a lone name or email is treated as not configured.
+			gitIdentityOverride: ({ formData }) => {
+				const name = str(formData, 'name');
+				const email = str(formData, 'email');
+				setOption('git_identity_name', name);
+				setOption('git_identity_email', email);
+				return success({ name, email });
 			},
 
 			// Tokens are stored plaintext in the options table and never sent back to the client.

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -19,6 +19,7 @@ import {
 	DEFAULT_SONNET_MODEL
 } from './container-injections/claude-code-custom.ts';
 import { hostEnvVarPresence, parseHostEnvVarNames } from './container-injections/host-env-vars.ts';
+import { gitIdentityEnabled } from './container-injections/git-identity.ts';
 import { browse } from './lib/picker.server.ts';
 import { pickNamePrompt } from './avatars/name-prompts.ts';
 import {
@@ -166,6 +167,7 @@ export const routes: Record<string, MochiRouteValue> = {
 				builtinCopyIgnore: DEFAULT_COPY_IGNORE,
 				// Not secrets, so the actual values (not just a "set" flag) go to the client.
 				// Blank means "no override" — fall back to the host's git config.
+				gitIdentityEnabled: gitIdentityEnabled(),
 				gitIdentityName: getOption('git_identity_name') ?? '',
 				gitIdentityEmail: getOption('git_identity_email') ?? '',
 				dockerArch: await dockerArch(),
@@ -214,10 +216,19 @@ export const routes: Record<string, MochiRouteValue> = {
 				return success({ patterns });
 			},
 
-			// Both fields must be saved together — a lone name or email is treated as not configured.
+			gitIdentityToggle: ({ formData }) => {
+				const enabled = onChecked(formData, 'enabled');
+				setOption('git_identity_enabled', enabled ? '1' : '0');
+				return success({ enabled });
+			},
+			// Both fields are required — the toggle governs whether the override applies, so a
+			// half-filled or empty identity is never a valid saved state.
 			gitIdentityOverride: ({ formData }) => {
 				const name = str(formData, 'name');
 				const email = str(formData, 'email');
+				if (!name || !email) {
+					return fail(400, { error: 'Both name and email are required.' });
+				}
 				setOption('git_identity_name', name);
 				setOption('git_identity_email', email);
 				return success({ name, email });


### PR DESCRIPTION
## Summary
- Add a `git_identity_name` / `git_identity_email` options-backed override to the `git-identity` container injection — when both are set, they always take precedence over the host's `git config --global user.name/email` (previously the only source, silently skipped when unset).
- Add a "Git identity" card to Settings for editing the override; leaving either field blank falls back to host detection, same "blank is valid" convention as `copy_ignore_patterns`.
- Both fields must be set together — a lone name or email is treated as not configured, mirroring the existing `name && email` check.

## Test plan
- [x] `bun run checks` (format + typecheck + tests) passes, including 5 new tests in `injections.isolated.test.ts` covering full override, partial-override fallback, blank-as-unset, and the `auth.status()` source string.
- [x] Manually verified against a running dev server: `POST /settings?/gitIdentityOverride` persists the override and the settings page reflects it back; clearing both fields falls back to unset.
- [ ] Full container boot with the override applied (not run — no Docker daemon in this environment).