### PR TITLE
feat(settings): manual Claude model override on the standard path

### DIFF
--- a/src/components/SettingsView.svelte
+++ b/src/components/SettingsView.svelte
@@ -1123,8 +1123,8 @@
 						<div class="text">
 							<div class="name">Model IDs</div>
 							<div class="desc">
-								A model name or alias per tier, e.g. <code>opus</code>, <code>sonnet</code>, or a
-								full
+								A model name or alias per tier, e.g. <code>opusplan</code>, <code>opus</code>,
+								<code>sonnet</code>, or a full
 								<code>claude-…</code> id. Leave a field blank to skip it.
 							</div>
 						</div>

--- a/src/components/SettingsView.svelte
+++ b/src/components/SettingsView.svelte
@@ -11,6 +11,7 @@
 	import Trash2 from '@lucide/svelte/icons/trash-2';
 	import Hammer from '@lucide/svelte/icons/hammer';
 	import KeyRound from '@lucide/svelte/icons/key-round';
+	import Cpu from '@lucide/svelte/icons/cpu';
 	import Variable from '@lucide/svelte/icons/variable';
 	import Plus from '@lucide/svelte/icons/plus';
 	import X from '@lucide/svelte/icons/x';
@@ -44,6 +45,12 @@
 		customEndpointHaikuModel,
 		customEndpointSmallFastModel,
 		customEndpointModel,
+		manualModelOverrideEnabled,
+		manualOpusModel,
+		manualSonnetModel,
+		manualHaikuModel,
+		manualSmallFastModel,
+		manualModel,
 		hostEnvVarsEnabled,
 		hostEnvVarNames,
 		hostEnvVarPresence,
@@ -66,6 +73,12 @@
 		customEndpointHaikuModel: string;
 		customEndpointSmallFastModel: string;
 		customEndpointModel: string;
+		manualModelOverrideEnabled: boolean;
+		manualOpusModel: string;
+		manualSonnetModel: string;
+		manualHaikuModel: string;
+		manualSmallFastModel: string;
+		manualModel: string;
 		hostEnvVarsEnabled: boolean;
 		hostEnvVarNames: string[];
 		hostEnvVarPresence: Record<string, boolean>;
@@ -291,7 +304,11 @@
 	const customEndpointToggleOpts = toggleOpts({
 		set: (v) => (customEndpoint = v),
 		setSaving: (v) => (savingCustomToggle = v),
-		setError: (v) => (customToggleError = v)
+		setError: (v) => (customToggleError = v),
+		// Enabling LiteLLM disables the manual override server-side; keep the UI in sync.
+		onSuccess: (data) => {
+			if ((data as { enabled?: boolean } | undefined)?.enabled) manualModelOverride = false;
+		}
 	});
 
 	// svelte-ignore state_referenced_locally
@@ -349,6 +366,49 @@
 			customModelsMsg = 'Saved.';
 		}
 	});
+
+	// svelte-ignore state_referenced_locally
+	let manualModelOverride = $state(manualModelOverrideEnabled);
+	let savingManualModelToggle = $state(false);
+	let manualModelToggleError = $state<string | null>(null);
+
+	const manualModelToggleOpts = toggleOpts({
+		set: (v) => (manualModelOverride = v),
+		setSaving: (v) => (savingManualModelToggle = v),
+		setError: (v) => (manualModelToggleError = v),
+		// Enabling this disables LiteLLM server-side; mirror that here so the UI stays consistent.
+		onSuccess: (data) => {
+			if ((data as { enabled?: boolean } | undefined)?.enabled) customEndpoint = false;
+		}
+	});
+
+	// svelte-ignore state_referenced_locally
+	let manualOpus = $state(manualOpusModel);
+	// svelte-ignore state_referenced_locally
+	let manualSonnet = $state(manualSonnetModel);
+	// svelte-ignore state_referenced_locally
+	let manualHaiku = $state(manualHaikuModel);
+	// svelte-ignore state_referenced_locally
+	let manualSmallFast = $state(manualSmallFastModel);
+	// svelte-ignore state_referenced_locally
+	let manualDefault = $state(manualModel);
+	let savingManualModels = $state(false);
+	let manualModelsMsg = $state<string | null>(null);
+	let manualModelsError = $state<string | null>(null);
+
+	const manualModelsOpts = saveOpts({
+		setSaving: (v) => (savingManualModels = v),
+		setError: (v) => (manualModelsError = v),
+		setMsg: (v) => (manualModelsMsg = v),
+		onSuccess: () => {
+			manualModelsMsg = 'Saved.';
+		}
+	});
+
+	// LiteLLM is incompatible with both manual tokens and the manual model override.
+	let litellmBlocker = $derived(
+		manualTokens ? 'Set tokens manually' : manualModelOverride ? 'Override models manually' : null
+	);
 
 	// Only names round-trip; `hostEnvPresence` is refreshed from each save response so a
 	// newly-added name doesn't read as "missing" until the next full page load.
@@ -791,7 +851,7 @@
 			{/if}
 		</section>
 
-		<section class="card" class:disabled-card={manualTokens}>
+		<section class="card" class:disabled-card={litellmBlocker}>
 			<form
 				class="row"
 				method="POST"
@@ -803,13 +863,13 @@
 					<div class="text">
 						<div class="name">
 							LiteLLM + Bedrock
-							{#if manualTokens}
-								<span class="arch" title="Disabled while Set tokens manually is on">disabled</span>
+							{#if litellmBlocker}
+								<span class="arch" title="Disabled while {litellmBlocker} is on">disabled</span>
 							{/if}
 						</div>
 						<div class="desc">
-							{#if manualTokens}
-								Not available while "Set tokens manually" is enabled — these modes are mutually
+							{#if litellmBlocker}
+								Not available while "{litellmBlocker}" is enabled — these modes are mutually
 								incompatible.
 							{:else}
 								Route <code>claude</code> through a LiteLLM proxy fronting AWS Bedrock instead of Anthropic's
@@ -824,7 +884,7 @@
 						type="checkbox"
 						name="enabled"
 						checked={customEndpoint}
-						disabled={savingCustomToggle || manualTokens}
+						disabled={savingCustomToggle || !!litellmBlocker}
 						onchange={(e) => {
 							customEndpoint = e.currentTarget.checked;
 							e.currentTarget.form?.requestSubmit();
@@ -1000,6 +1060,149 @@
 						<div class="msg error">{customModelsError}</div>
 					{:else if customModelsMsg}
 						<div class="msg ok">{customModelsMsg}</div>
+					{/if}
+				</form>
+			{/if}
+		</section>
+
+		<section class="card" class:disabled-card={customEndpoint}>
+			<form
+				class="row"
+				method="POST"
+				action="?/manualModelToggle"
+				{@attach enhance(manualModelToggleOpts)}
+			>
+				<div class="label">
+					<Cpu size={18} />
+					<div class="text">
+						<div class="name">
+							Override models manually
+							{#if customEndpoint}
+								<span class="arch" title="Disabled while LiteLLM + Bedrock is on">disabled</span>
+							{/if}
+						</div>
+						<div class="desc">
+							{#if customEndpoint}
+								Not available while "LiteLLM + Bedrock" is enabled — these modes are mutually
+								incompatible.
+							{:else}
+								Pin which model <code>claude</code> uses on the standard (subscription) path. Only
+								the fields you fill are injected into new containers as
+								<code>ANTHROPIC_*_MODEL</code>
+								variables; blanks fall through to Claude Code's own defaults.
+							{/if}
+						</div>
+					</div>
+				</div>
+				<label class="switch">
+					<input
+						type="checkbox"
+						name="enabled"
+						checked={manualModelOverride}
+						disabled={savingManualModelToggle || customEndpoint}
+						onchange={(e) => {
+							manualModelOverride = e.currentTarget.checked;
+							e.currentTarget.form?.requestSubmit();
+						}}
+					/>
+					<span class="track"><span class="thumb"></span></span>
+				</label>
+			</form>
+			{#if manualModelToggleError}
+				<div class="sub"><div class="msg error">{manualModelToggleError}</div></div>
+			{/if}
+
+			{#if manualModelOverride}
+				<form
+					class="row divided token-row"
+					method="POST"
+					action="?/manualModels"
+					{@attach enhance(manualModelsOpts)}
+				>
+					<div class="label">
+						<div class="text">
+							<div class="name">Model IDs</div>
+							<div class="desc">
+								A model name or alias per tier, e.g. <code>opus</code>, <code>sonnet</code>, or a
+								full
+								<code>claude-…</code> id. Leave a field blank to skip it.
+							</div>
+						</div>
+					</div>
+					<div class="model-fields">
+						<label class="model-row">
+							<span class="model-label">Opus</span>
+							<input
+								type="text"
+								name="opusModel"
+								class="image-input"
+								bind:value={manualOpus}
+								spellcheck="false"
+								autocapitalize="off"
+								autocorrect="off"
+								autocomplete="off"
+							/>
+						</label>
+						<label class="model-row">
+							<span class="model-label">Sonnet</span>
+							<input
+								type="text"
+								name="sonnetModel"
+								class="image-input"
+								bind:value={manualSonnet}
+								spellcheck="false"
+								autocapitalize="off"
+								autocorrect="off"
+								autocomplete="off"
+							/>
+						</label>
+						<label class="model-row">
+							<span class="model-label">Haiku</span>
+							<input
+								type="text"
+								name="haikuModel"
+								class="image-input"
+								bind:value={manualHaiku}
+								spellcheck="false"
+								autocapitalize="off"
+								autocorrect="off"
+								autocomplete="off"
+							/>
+						</label>
+						<label class="model-row">
+							<span class="model-label">Small/fast</span>
+							<input
+								type="text"
+								name="smallFastModel"
+								class="image-input"
+								bind:value={manualSmallFast}
+								spellcheck="false"
+								autocapitalize="off"
+								autocorrect="off"
+								autocomplete="off"
+							/>
+						</label>
+						<label class="model-row">
+							<span class="model-label">Default</span>
+							<input
+								type="text"
+								name="defaultModel"
+								class="image-input"
+								bind:value={manualDefault}
+								spellcheck="false"
+								autocapitalize="off"
+								autocorrect="off"
+								autocomplete="off"
+							/>
+						</label>
+						<div class="model-save-row">
+							<Button type="submit" disabled={savingManualModels}>Save models</Button>
+						</div>
+					</div>
+					{#if manualModelsError}
+						<div class="msg error">{manualModelsError}</div>
+					{:else if manualModelsMsg}
+						<div class="msg ok">{manualModelsMsg}</div>
 					{/if}
 				</form>
 			{/if}

--- a/src/container-injections/claude-code-models.ts
+++ b/src/container-injections/claude-code-models.ts
@@ -1,0 +1,74 @@
+import { getOption } from '../lib/db.server.ts';
+import { execInContainer } from '../lib/exec.server.ts';
+import type { ContainerTarget, Injection } from '../lib/injections.server.ts';
+
+/** The option key → Claude env var mapping; order is the field order in Settings. */
+const MODEL_ENV: Array<[key: string, env: string]> = [
+	['manual_opus_model', 'ANTHROPIC_DEFAULT_OPUS_MODEL'],
+	['manual_sonnet_model', 'ANTHROPIC_DEFAULT_SONNET_MODEL'],
+	['manual_haiku_model', 'ANTHROPIC_DEFAULT_HAIKU_MODEL'],
+	['manual_small_fast_model', 'ANTHROPIC_SMALL_FAST_MODEL'],
+	['manual_model', 'ANTHROPIC_MODEL']
+];
+
+/**
+ * Only for the standard (subscription) path — null when disabled, when LiteLLM
+ * owns the models instead, or when no field is filled (nothing to export).
+ */
+export function manualModelConfig(): Record<string, string> | null {
+	if (getOption('manual_model_override_enabled') !== '1') return null;
+	if (getOption('custom_endpoint_enabled') === '1') return null;
+	const filled: Record<string, string> = {};
+	for (const [key, env] of MODEL_ENV) {
+		const value = getOption(key)?.trim();
+		if (value) filled[env] = value;
+	}
+	return Object.keys(filled).length ? filled : null;
+}
+
+const ENV_FILE = '~/.codebay-claude-models-env';
+
+/** Model IDs are non-secret, so every value rides `args` ($1, $2, …) — no stdin. */
+async function injectModels(
+	target: ContainerTarget,
+	config: Record<string, string>
+): Promise<{ ok: boolean; error?: string }> {
+	const entries = Object.entries(config);
+	const writes = entries.map(([env], i) => `printf 'export ${env}=%s\\n' "$${i + 1}"; `).join('');
+	const script =
+		'set -e; f=$(eval echo "' +
+		ENV_FILE +
+		'"); ' +
+		'{ ' +
+		writes +
+		'} > "$f"; chmod 600 "$f"; ' +
+		// The grep guard keeps a re-apply from stacking duplicate source lines.
+		'h=$(eval echo ~$(id -un)); src="[ -f \\"$f\\" ] && . \\"$f\\""; ' +
+		'for rc in "$h/.bashrc" "$h/.zshrc"; do ' +
+		'grep -qF "$src" "$rc" 2>/dev/null || printf \'%s\\n\' "$src" >> "$rc"; ' +
+		'done';
+
+	const res = await execInContainer(target, {
+		script,
+		args: ['claude-models', ...entries.map(([, value]) => value)]
+	});
+	return res.ok ? { ok: true } : { ok: false, error: res.error };
+}
+
+/** Sets Claude model env vars on the standard path; skipped when LiteLLM is active. */
+export const claudeCodeModels: Injection = {
+	id: 'claude-code-models',
+	label: 'Model override',
+
+	async apply(target, log) {
+		const config = manualModelConfig();
+		if (!config) return;
+		log(`Injecting Claude model override (${Object.keys(config).join(', ')})…\n`);
+		const result = await injectModels(target, config);
+		log(
+			result.ok
+				? '✓ Claude model override configured in container\n'
+				: `⚠ Claude model override injection failed: ${result.error}\n`
+		);
+	}
+};

--- a/src/container-injections/injections.isolated.test.ts
+++ b/src/container-injections/injections.isolated.test.ts
@@ -7,6 +7,7 @@ import { setOption } from '../lib/db.server.ts';
 import { attentionHookSettings } from './attention-hooks.ts';
 import { isValid, LIVE_CREDENTIALS_TEST, tokenCredentials } from './claude-code-credentials.ts';
 import { customEndpointConfig } from './claude-code-custom.ts';
+import { manualModelConfig } from './claude-code-models.ts';
 import { ghHostBlock, parseGhHosts } from './github-credentials.ts';
 import { hostEnvVarPresence, hostEnvVarsConfig, parseHostEnvVarNames } from './host-env-vars.ts';
 import { extractScriptPath } from './claude-statusline.ts';
@@ -237,6 +238,87 @@ describe('customEndpointConfig', () => {
 		const config = customEndpointConfig()!;
 		expect(config.opusModel).toBe('my-custom-opus');
 		setOption('custom_endpoint_opus_model', ''); // cleanup
+	});
+});
+
+describe('manualModelConfig', () => {
+	const MODEL_KEYS = [
+		'manual_opus_model',
+		'manual_sonnet_model',
+		'manual_haiku_model',
+		'manual_small_fast_model',
+		'manual_model'
+	];
+	function reset() {
+		setOption('manual_model_override_enabled', '0');
+		setOption('custom_endpoint_enabled', '0');
+		for (const k of MODEL_KEYS) setOption(k, '');
+	}
+	beforeEach(reset);
+	afterEach(reset);
+
+	test('returns null when the override is disabled', () => {
+		setOption('manual_model', 'opus');
+		expect(manualModelConfig()).toBeNull();
+	});
+
+	test('returns null when LiteLLM is enabled (mutually exclusive)', () => {
+		setOption('manual_model_override_enabled', '1');
+		setOption('custom_endpoint_enabled', '1');
+		setOption('manual_model', 'opus');
+		expect(manualModelConfig()).toBeNull();
+	});
+
+	test('returns null when enabled but every field is blank', () => {
+		setOption('manual_model_override_enabled', '1');
+		expect(manualModelConfig()).toBeNull();
+	});
+
+	test('exports only the filled fields, mapped to their env vars', () => {
+		setOption('manual_model_override_enabled', '1');
+		setOption('manual_model', 'opusplan');
+		setOption('manual_small_fast_model', 'haiku');
+		expect(manualModelConfig()).toEqual({
+			ANTHROPIC_MODEL: 'opusplan',
+			ANTHROPIC_SMALL_FAST_MODEL: 'haiku'
+		});
+	});
+
+	test('maps all five tiers when fully filled', () => {
+		setOption('manual_model_override_enabled', '1');
+		setOption('manual_opus_model', 'o');
+		setOption('manual_sonnet_model', 's');
+		setOption('manual_haiku_model', 'h');
+		setOption('manual_small_fast_model', 'sf');
+		setOption('manual_model', 'd');
+		expect(manualModelConfig()).toEqual({
+			ANTHROPIC_DEFAULT_OPUS_MODEL: 'o',
+			ANTHROPIC_DEFAULT_SONNET_MODEL: 's',
+			ANTHROPIC_DEFAULT_HAIKU_MODEL: 'h',
+			ANTHROPIC_SMALL_FAST_MODEL: 'sf',
+			ANTHROPIC_MODEL: 'd'
+		});
+	});
+});
+
+describe('claude-code-models registry', () => {
+	test('is present regardless of the custom-endpoint toggle (self-guards at apply time)', () => {
+		setOption('custom_endpoint_enabled', '0');
+		expect(resolveInjections().map((i) => i.id)).toContain('claude-code-models');
+		setOption('custom_endpoint_enabled', '1');
+		setOption('custom_endpoint_base_url', 'https://litellm.example.com/bedrock');
+		setOption('custom_endpoint_token', 'sk-test');
+		expect(resolveInjections().map((i) => i.id)).toContain('claude-code-models');
+		setOption('custom_endpoint_enabled', '0');
+		setOption('custom_endpoint_base_url', '');
+		setOption('custom_endpoint_token', '');
+	});
+
+	test('carries no auth chip and no health check', () => {
+		const models = injections.find((i) => i.id === 'claude-code-models');
+		expect(models).toBeDefined();
+		expect(models!.auth).toBeUndefined();
+		expect(models!.check).toBeUndefined();
 	});
 });
 

--- a/src/lib/injections.server.ts
+++ b/src/lib/injections.server.ts
@@ -6,6 +6,7 @@ import { tmux } from '../container-injections/tmux.ts';
 import { gitIdentity } from '../container-injections/git-identity.ts';
 import { claudeCodeCredentials } from '../container-injections/claude-code-credentials.ts';
 import { claudeCodeCustom } from '../container-injections/claude-code-custom.ts';
+import { claudeCodeModels } from '../container-injections/claude-code-models.ts';
 import { githubCredentials } from '../container-injections/github-credentials.ts';
 import { attentionHooks } from '../container-injections/attention-hooks.ts';
 import { claudeStatusline } from '../container-injections/claude-statusline.ts';
@@ -48,6 +49,8 @@ const BASE_INJECTIONS_HEAD: Injection[] = [
 ];
 
 const BASE_INJECTIONS_TAIL: Injection[] = [
+	// Self-skips unless manual override is on and LiteLLM off, so it's safe in the always-run tail.
+	claudeCodeModels,
 	githubCredentials,
 	attentionHooks,
 	claudeStatusline,

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -21,6 +21,12 @@
 		customEndpointHaikuModel,
 		customEndpointSmallFastModel,
 		customEndpointModel,
+		manualModelOverrideEnabled,
+		manualOpusModel,
+		manualSonnetModel,
+		manualHaikuModel,
+		manualSmallFastModel,
+		manualModel,
 		hostEnvVarsEnabled,
 		hostEnvVarNames,
 		hostEnvVarPresence,
@@ -43,6 +49,12 @@
 		customEndpointHaikuModel: string;
 		customEndpointSmallFastModel: string;
 		customEndpointModel: string;
+		manualModelOverrideEnabled: boolean;
+		manualOpusModel: string;
+		manualSonnetModel: string;
+		manualHaikuModel: string;
+		manualSmallFastModel: string;
+		manualModel: string;
 		hostEnvVarsEnabled: boolean;
 		hostEnvVarNames: string[];
 		hostEnvVarPresence: Record<string, boolean>;
@@ -68,6 +80,12 @@
 	{customEndpointHaikuModel}
 	{customEndpointSmallFastModel}
 	{customEndpointModel}
+	{manualModelOverrideEnabled}
+	{manualOpusModel}
+	{manualSonnetModel}
+	{manualHaikuModel}
+	{manualSmallFastModel}
+	{manualModel}
 	{hostEnvVarsEnabled}
 	{hostEnvVarNames}
 	{hostEnvVarPresence}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -182,6 +182,14 @@ export const routes: Record<string, MochiRouteValue> = {
 				customEndpointSmallFastModel:
 					getOption('custom_endpoint_small_fast_model') ?? DEFAULT_SMALL_FAST_MODEL,
 				customEndpointModel: getOption('custom_endpoint_model') ?? DEFAULT_MODEL,
+				// Manual model override (standard subscription path): toggle + five blank-by-default
+				// model IDs — only the ones the user fills get injected, so no Bedrock-default seeding.
+				manualModelOverrideEnabled: getOption('manual_model_override_enabled') === '1',
+				manualOpusModel: getOption('manual_opus_model') ?? '',
+				manualSonnetModel: getOption('manual_sonnet_model') ?? '',
+				manualHaikuModel: getOption('manual_haiku_model') ?? '',
+				manualSmallFastModel: getOption('manual_small_fast_model') ?? '',
+				manualModel: getOption('manual_model') ?? '',
 				hostEnvVarsEnabled: getOption('host_env_vars_enabled') === '1',
 				hostEnvVarNames,
 				hostEnvVarPresence: hostEnvVarPresence(hostEnvVarNames),
@@ -230,6 +238,8 @@ export const routes: Record<string, MochiRouteValue> = {
 			customEndpointToggle: ({ formData }) => {
 				const enabled = onChecked(formData, 'enabled');
 				setOption('custom_endpoint_enabled', enabled ? '1' : '0');
+				// LiteLLM and the manual model override own the same env vars — never both.
+				if (enabled) setOption('manual_model_override_enabled', '0');
 				return success({ enabled });
 			},
 			customBaseUrl: ({ formData }) => {
@@ -248,6 +258,22 @@ export const routes: Record<string, MochiRouteValue> = {
 				setOption('custom_endpoint_haiku_model', str(formData, 'haikuModel'));
 				setOption('custom_endpoint_small_fast_model', str(formData, 'smallFastModel'));
 				setOption('custom_endpoint_model', str(formData, 'defaultModel'));
+				return success({});
+			},
+
+			manualModelToggle: ({ formData }) => {
+				const enabled = onChecked(formData, 'enabled');
+				setOption('manual_model_override_enabled', enabled ? '1' : '0');
+				// Reciprocal of customEndpointToggle — the two can't both drive model env vars.
+				if (enabled) setOption('custom_endpoint_enabled', '0');
+				return success({ enabled });
+			},
+			manualModels: ({ formData }) => {
+				setOption('manual_opus_model', str(formData, 'opusModel'));
+				setOption('manual_sonnet_model', str(formData, 'sonnetModel'));
+				setOption('manual_haiku_model', str(formData, 'haikuModel'));
+				setOption('manual_small_fast_model', str(formData, 'smallFastModel'));
+				setOption('manual_model', str(formData, 'defaultModel'));
 				return success({});
 			},
 


### PR DESCRIPTION
## What

Adds a **Override models manually** card to Settings that lets a subscription/OAuth user pin which Claude Code models get used per instance — the missing counterpart to the LiteLLM + Bedrock card, which was previously the only way to set model IDs.

Five optional fields (Opus, Sonnet, Haiku, Small/fast, Default) map to `ANTHROPIC_DEFAULT_OPUS/SONNET/HAIKU_MODEL`, `ANTHROPIC_SMALL_FAST_MODEL`, and `ANTHROPIC_MODEL`. **Only the fields you fill are injected** into new containers; blanks fall through to Claude Code's own defaults (so no invalid Bedrock IDs leak onto the subscription path).

## Mutual exclusion with LiteLLM

The two modes both drive the same env vars, so they can never both be on:

- Enabling manual override sets `custom_endpoint_enabled=0`; enabling LiteLLM sets `manual_model_override_enabled=0` — enforced **server-side** in the toggle actions (`routes.ts`).
- The UI mirrors it: each card is greyed out / its toggle disabled while the other is on (reuses the existing `disabled-card` pattern already shared by the manual-tokens ↔ LiteLLM pair).

## How it's built

- New self-contained injection `src/container-injections/claude-code-models.ts`. `manualModelConfig()` returns `null` when the toggle is off, when LiteLLM owns the models, or when every field is blank — so the module is safe in the always-run tail (`BASE_INJECTIONS_TAIL`) and needs no change to `resolveInjections()`.
- Non-secret model IDs ride `execInContainer` `args` (no stdin); the filled vars are written to `~/.codebay-claude-models-env` and sourced from `.bashrc`/`.zshrc` with the same idempotent grep guard the LiteLLM injection uses. Distinct filename keeps LiteLLM's health `check()` unambiguous.
- No auth chip and no health check — it's an opt-in convenience with no host dependency, so it stays out of the credentials chips and the health list.
- New option keys (`manual_model_override_enabled`, `manual_opus_model`, …) in the existing generic key/value store — no migration.

## Tests

`bun run checks` passes (145 tests). Added `manualModelConfig` coverage: null when disabled / when LiteLLM on / when all blank; exports only filled fields mapped to the right env vars; plus registry assertions (always present, no auth, no check).

## Manual verification

- Toggling either card off the other, persisted across reload.
- Filling only the Default model then booting an instance: `~/.codebay-claude-models-env` contains only `ANTHROPIC_MODEL`, sourced in a fresh shell; empty fields absent; with override off the file is absent and behavior is unchanged.