### PR TITLE
Close popup tabs on back instead of navigating home

### DIFF
--- a/src/components/AppBar.svelte
+++ b/src/components/AppBar.svelte
@@ -1,12 +1,19 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 	import House from '@lucide/svelte/icons/house';
+	import { onBackLinkClick } from '../lib/popup-nav.ts';
 
 	let { children }: { children?: Snippet } = $props();
 </script>
 
 <header class="bar">
-	<a class="home" href="/" title="All instances" aria-label="All instances"><House size={18} /></a>
+	<a
+		class="home"
+		href="/"
+		title="All instances"
+		aria-label="All instances"
+		onclick={onBackLinkClick}><House size={18} /></a
+	>
 	{@render children?.()}
 </header>
 

--- a/src/components/IdeBar.svelte
+++ b/src/components/IdeBar.svelte
@@ -3,6 +3,7 @@
 	import Settings from '@lucide/svelte/icons/settings';
 	import Avatar from './Avatar.svelte';
 	import AppBar from './AppBar.svelte';
+	import { withPopupMarker } from '../lib/popup-nav.ts';
 
 	let {
 		running,
@@ -69,7 +70,14 @@
 			{/each}
 		</nav>
 	{/if}
-	<a class="cog" href="/settings" title="Settings" aria-label="Settings"><Settings size={18} /></a>
+	<a
+		class="cog"
+		href={withPopupMarker('/settings')}
+		target="_blank"
+		rel="noopener noreferrer"
+		title="Settings"
+		aria-label="Settings"><Settings size={18} /></a
+	>
 </AppBar>
 
 <style>

--- a/src/components/InstanceCard.svelte
+++ b/src/components/InstanceCard.svelte
@@ -5,6 +5,7 @@
 	import PortsBox from './PortsBox.svelte';
 	import StatusBadge from './StatusBadge.svelte';
 	import Button from './Button.svelte';
+	import { withPopupMarker } from '../lib/popup-nav.ts';
 
 	let {
 		instance,
@@ -81,8 +82,11 @@
 		{:else if instance.status === 'stopped' || (instance.status === 'error' && instance.container_id)}
 			<Button size="sm" onclick={() => onact('start')}>Start</Button>
 		{:else if instance.status === 'creating'}
-			<Button size="sm" href={`/instances/${instance.id}`} target="_blank" rel="noopener noreferrer"
-				>View logs</Button
+			<Button
+				size="sm"
+				href={withPopupMarker(`/instances/${instance.id}`)}
+				target="_blank"
+				rel="noopener noreferrer">View logs</Button
 			>
 		{/if}
 		{#if canRebuild}
@@ -95,7 +99,7 @@
 		<Button
 			size="sm"
 			ghost
-			href={`/instances/${instance.id}`}
+			href={withPopupMarker(`/instances/${instance.id}`)}
 			target="_blank"
 			rel="noopener noreferrer">Details</Button
 		>

--- a/src/components/InstanceView.svelte
+++ b/src/components/InstanceView.svelte
@@ -10,6 +10,7 @@
 	import { apiPost, apiDelete } from '../api.ts';
 	import { enhance } from 'mochi-framework';
 	import type { MochiEnhanceOptions } from 'mochi-framework';
+	import { onBackLinkClick, installPopupBackTrap } from '../lib/popup-nav.ts';
 
 	let { id, injectionChecks = 0 }: { id: string; injectionChecks?: number } = $props();
 
@@ -23,6 +24,8 @@
 		void logs; // the dependency this effect exists for
 		node.scrollTop = node.scrollHeight;
 	}
+
+	$effect(() => installPopupBackTrap());
 
 	// Reset on every connect, because the server replays its whole buffer each time.
 	$effect(() =>
@@ -120,7 +123,7 @@
 </script>
 
 <header class="topbar">
-	<a class="back" href="/"><ArrowLeft size={15} /> All instances</a>
+	<a class="back" href="/" onclick={onBackLinkClick}><ArrowLeft size={15} /> All instances</a>
 	<div class="title">
 		<span class="name">{instance?.name ?? 'Instance'}</span>
 		{#if instance}

--- a/src/components/SettingsCog.svelte
+++ b/src/components/SettingsCog.svelte
@@ -1,8 +1,16 @@
 <script lang="ts">
 	import Settings from '@lucide/svelte/icons/settings';
+	import { withPopupMarker } from '../lib/popup-nav.ts';
 </script>
 
-<a class="cog" href="/settings" aria-label="Settings" title="Settings"><Settings size={16} /></a>
+<a
+	class="cog"
+	href={withPopupMarker('/settings')}
+	target="_blank"
+	rel="noopener noreferrer"
+	aria-label="Settings"
+	title="Settings"><Settings size={16} /></a
+>
 
 <style>
 	.cog {

--- a/src/components/SettingsView.svelte
+++ b/src/components/SettingsView.svelte
@@ -22,6 +22,7 @@
 	import { playChime, unlockAudio } from '../sound.ts';
 	import Button from './Button.svelte';
 	import CoinButton from './CoinButton.svelte';
+	import { installPopupBackTrap } from '../lib/popup-nav.ts';
 
 	/** Every settings form action fails with the same `{ error }` shape. */
 	type ActionFailure = { error: string };
@@ -76,6 +77,8 @@
 	let sound = $state(soundEnabled());
 
 	let shuttingDown = $state(false);
+
+	$effect(() => installPopupBackTrap());
 
 	/** Reused by every plain save form below; only the per-control state setters differ. */
 	function saveOpts<Success extends Record<string, unknown> = Record<string, unknown>>(handlers: {

--- a/src/lib/popup-nav.ts
+++ b/src/lib/popup-nav.ts
@@ -1,0 +1,37 @@
+const POPUP_PARAM = 'popup';
+
+/** Assumes `href` has no existing query string. */
+export function withPopupMarker(href: string): string {
+	return `${href}?${POPUP_PARAM}=1`;
+}
+
+export function isPopupPage(): boolean {
+	return new URLSearchParams(location.search).has(POPUP_PARAM);
+}
+
+function closeOrGoHome() {
+	window.close();
+	// Runs only if close() was refused (tab wasn't opened by script) — window.close()
+	// tears the page down near-instantly when it succeeds, so this never fires then.
+	setTimeout(() => {
+		location.href = '/';
+	}, 100);
+}
+
+export function onBackLinkClick(e: MouseEvent) {
+	if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey)
+		return;
+	if (!isPopupPage()) return;
+	e.preventDefault();
+	closeOrGoHome();
+}
+
+export function installPopupBackTrap(): () => void {
+	if (!isPopupPage()) return () => {};
+	// A fresh popup tab has one history entry, so back is otherwise a no-op the
+	// browser just disables — push a duplicate so the first back press fires popstate.
+	history.pushState({}, '', location.href);
+	const onPop = () => closeOrGoHome();
+	window.addEventListener('popstate', onPop);
+	return () => window.removeEventListener('popstate', onPop);
+}


### PR DESCRIPTION
## Summary
- Settings and instance-detail pages (`/settings`, `/instances/:id`) are full-page-load routes outside the SPA shell; today "back" (the home icon / the instance-detail page's own back-arrow link) always hard-navigates to `/`, even when the page was opened as a popup off the dashboard and `/` is already open in another tab.
- `/settings` now opens in a new tab too (matching how "View Logs"/"Details" already open instance details), marked with a `?popup=1` query param.
- On a popup-marked page, both the home icon / back-arrow link and the browser's native back button/gesture now close the tab instead, falling back to navigating to `/` if the browser refuses to close it (e.g. not considered script-opened).
- Pages loaded without the marker (e.g. a bookmarked/typed URL) behave exactly as before.

New shared client helper: `src/lib/popup-nav.ts`.

## Test plan
- [x] `bun run checks` (format, typecheck, 138 tests) — all green
- [x] Confirmed via SSR output that `/settings` and instance-detail links render with `?popup=1`, `target="_blank"`, `rel="noopener noreferrer"`
- [ ] Manual click-through in a real browser (couldn't be done in this sandbox — no GUI/headless browser available): open Settings and an instance's Details from the dashboard, confirm the tab closes on both the in-page back link and the native back button/gesture, and confirm settings opened from inside an IDE tab no longer tears down the SPA shell's mounted iframes.