### PR TITLE
feat: propagate host Claude model default and suppress attribution

### DIFF
--- a/src/container-injections/claude-model.ts
+++ b/src/container-injections/claude-model.ts
@@ -1,0 +1,66 @@
+import { getOption } from '../lib/db.server.ts';
+import { checkPresence, execInContainer } from '../lib/exec.server.ts';
+import { mergeClaudeSettingsScript } from './attention-hooks.ts';
+import { readHostClaudeSettings } from './claude-statusline.ts';
+import type { ContainerTarget, Injection } from '../lib/injections.server.ts';
+
+/** The app's own model config (manual override / LiteLLM) exports ANTHROPIC_MODEL, which wins over settings.json. */
+function appOwnsModel(): boolean {
+	return (
+		getOption('manual_model_override_enabled') === '1' ||
+		getOption('custom_endpoint_enabled') === '1'
+	);
+}
+
+/** The `model` default from host ~/.claude/settings.json, or null when unset or app-owned. */
+export async function hostClaudeModel(): Promise<string | null> {
+	if (appOwnsModel()) return null;
+	const settings = await readHostClaudeSettings();
+	const model = settings?.model;
+	return typeof model === 'string' && model.trim() ? model.trim() : null;
+}
+
+async function injectModel(
+	target: ContainerTarget,
+	model: string
+): Promise<{ ok: boolean; error?: string }> {
+	const res = await execInContainer(target, {
+		script: mergeClaudeSettingsScript(),
+		stdin: JSON.stringify({ model })
+	});
+	return res.ok ? { ok: true } : { ok: false, error: res.error };
+}
+
+/** Mirrors the host's default `model` into the container so subscription instances match the host. */
+export const claudeModel: Injection = {
+	id: 'claude-model',
+	label: 'model default',
+
+	auth: {
+		hint: 'set `model` in ~/.claude/settings.json',
+		async status() {
+			const model = await hostClaudeModel();
+			return { available: model !== null, source: model ? '~/.claude/settings.json' : null };
+		}
+	},
+
+	async apply(target, log) {
+		const model = await hostClaudeModel();
+		if (!model) return;
+		log(`Injecting Claude model default (${model})…\n`);
+		const result = await injectModel(target, model);
+		log(
+			result.ok
+				? '✓ Claude model default configured in container\n'
+				: `⚠ Claude model default injection failed: ${result.error}\n`
+		);
+	},
+
+	async check(target) {
+		return checkPresence(
+			target,
+			'h=$(eval echo ~$(id -un)); d="${CLAUDE_CONFIG_DIR:-$h/.claude}"; ' +
+				'[ -s "$d/settings.json" ] && grep -q \'"model"\' "$d/settings.json" && echo 1 || echo 0'
+		);
+	}
+};

--- a/src/container-injections/claude-no-coauthor.ts
+++ b/src/container-injections/claude-no-coauthor.ts
@@ -2,10 +2,20 @@ import { checkPresence, execInContainer } from '../lib/exec.server.ts';
 import { mergeClaudeSettingsScript } from './attention-hooks.ts';
 import type { ContainerTarget, Injection } from '../lib/injections.server.ts';
 
+/**
+ * Both schemas on purpose: newer `claude` reads the nested `attribution` object, older builds
+ * the root-level `includeCoAuthoredBy` — setting both suppresses the byline across versions.
+ * Empty `commit`/`pr` strings drop the commit trailer and PR footer.
+ */
+export const NO_COAUTHOR_SETTINGS = {
+	includeCoAuthoredBy: false,
+	attribution: { commit: '', pr: '', includeCoAuthoredBy: false }
+};
+
 async function injectNoCoauthor(target: ContainerTarget): Promise<{ ok: boolean; error?: string }> {
 	const res = await execInContainer(target, {
 		script: mergeClaudeSettingsScript(),
-		stdin: JSON.stringify({ includeCoAuthoredBy: false })
+		stdin: JSON.stringify(NO_COAUTHOR_SETTINGS)
 	});
 	return res.ok ? { ok: true } : { ok: false, error: res.error };
 }

--- a/src/container-injections/claude-statusline.ts
+++ b/src/container-injections/claude-statusline.ts
@@ -15,7 +15,7 @@ interface StatusLineConfig {
 	script?: string;
 }
 
-async function readHostClaudeSettings(): Promise<Record<string, unknown> | null> {
+export async function readHostClaudeSettings(): Promise<Record<string, unknown> | null> {
 	const file = join(homedir(), '.claude', 'settings.json');
 	if (!existsSync(file)) return null;
 	try {

--- a/src/container-injections/injections.isolated.test.ts
+++ b/src/container-injections/injections.isolated.test.ts
@@ -12,6 +12,8 @@ import { manualModelConfig } from './claude-code-models.ts';
 import { ghHostBlock, parseGhHosts } from './github-credentials.ts';
 import { hostEnvVarPresence, hostEnvVarsConfig, parseHostEnvVarNames } from './host-env-vars.ts';
 import { expandTilde, extractScriptPath } from './claude-statusline.ts';
+import { hostClaudeModel } from './claude-model.ts';
+import { NO_COAUTHOR_SETTINGS } from './claude-no-coauthor.ts';
 import { homedir } from 'node:os';
 import { INSTALL_SCRIPT, TMUX_CONF_LINES } from './tmux.ts';
 
@@ -73,6 +75,13 @@ describe('injection registry', () => {
 		expect(statusline).toBeDefined();
 		expect(statusline!.auth).toBeDefined();
 		expect(typeof statusline!.check).toBe('function');
+	});
+
+	test('claude-model is registered with an auth chip and a health check', () => {
+		const model = injections.find((i) => i.id === 'claude-model');
+		expect(model).toBeDefined();
+		expect(model!.auth).toBeDefined();
+		expect(typeof model!.check).toBe('function');
 	});
 
 	test('host-env-vars is registered with a health check and no auth chip', () => {
@@ -361,6 +370,36 @@ describe('manualModelConfig', () => {
 			ANTHROPIC_DEFAULT_HAIKU_MODEL: 'h',
 			ANTHROPIC_SMALL_FAST_MODEL: 'sf',
 			ANTHROPIC_MODEL: 'd'
+		});
+	});
+});
+
+describe('hostClaudeModel', () => {
+	function reset() {
+		setOption('manual_model_override_enabled', '0');
+		setOption('custom_endpoint_enabled', '0');
+	}
+	beforeEach(reset);
+	afterEach(reset);
+
+	test('is null when the manual model override owns the model', async () => {
+		setOption('manual_model_override_enabled', '1');
+		expect(await hostClaudeModel()).toBeNull();
+	});
+
+	test('is null when LiteLLM owns the model', async () => {
+		setOption('custom_endpoint_enabled', '1');
+		expect(await hostClaudeModel()).toBeNull();
+	});
+});
+
+describe('NO_COAUTHOR_SETTINGS', () => {
+	test('suppresses the byline via both the root and nested attribution schemas', () => {
+		expect(NO_COAUTHOR_SETTINGS.includeCoAuthoredBy).toBe(false);
+		expect(NO_COAUTHOR_SETTINGS.attribution).toEqual({
+			commit: '',
+			pr: '',
+			includeCoAuthoredBy: false
 		});
 	});
 });

--- a/src/lib/injections.server.ts
+++ b/src/lib/injections.server.ts
@@ -10,6 +10,7 @@ import { claudeCodeModels } from '../container-injections/claude-code-models.ts'
 import { githubCredentials } from '../container-injections/github-credentials.ts';
 import { attentionHooks } from '../container-injections/attention-hooks.ts';
 import { claudeStatusline } from '../container-injections/claude-statusline.ts';
+import { claudeModel } from '../container-injections/claude-model.ts';
 import { claudeSkipPermissions } from '../container-injections/claude-skip-permissions.ts';
 import { claudeAliases } from '../container-injections/claude-aliases.ts';
 import { claudeNoCoauthor } from '../container-injections/claude-no-coauthor.ts';
@@ -54,6 +55,7 @@ const BASE_INJECTIONS_TAIL: Injection[] = [
 	githubCredentials,
 	attentionHooks,
 	claudeStatusline,
+	claudeModel,
 	claudeSkipPermissions,
 	claudeAliases,
 	claudeNoCoauthor,


### PR DESCRIPTION
## What & why

Containers assemble their own `~/.claude/settings.json` from injections, but the manager **never read the host's `model` default** — so a local `"model": "claude-opus-4-8"` in `~/.claude/settings.json` never reached containers, and they fell back to Claude Code's built-in default (Opus 5). Reported when a container kept starting on Opus 5 despite the host override.

## Changes

- **New `claude-model` injection** (`src/container-injections/claude-model.ts`): mirrors the host `settings.json` `model` into each container via the shared `mergeClaudeSettingsScript()` deep-merge. Skipped when the app's own **manual model override** or **LiteLLM** is active — those export `ANTHROPIC_MODEL`, which wins over `settings.json` anyway, so gating keeps a stale value out of the file. Exposes an `auth` chip (available when host `settings.json` has a `model`) and a health `check()`, wired in via `BASE_INJECTIONS_TAIL`.
  - Reuses `readHostClaudeSettings()`, now exported from `claude-statusline.ts` (previously the only reader of the host settings file, for `statusLine` only).
- **Attribution / co-author suppression** (`claude-no-coauthor.ts`): now writes **both** the legacy root-level `includeCoAuthoredBy: false` **and** the current nested `attribution: { commit: "", pr: "", includeCoAuthoredBy: false }`, so the commit trailer and PR footer are suppressed across Claude Code versions.

## Tests

Extended `injections.isolated.test.ts`: registry wiring for `claude-model`, `hostClaudeModel()` gating (null when the app owns the model), and the `NO_COAUTHOR_SETTINGS` shape.

`bun run checks` passes (163 tests, typecheck clean).

## Verification

Manual end-to-end: create an instance, then in the container confirm `~/.claude/settings.json` contains `"model"` matching the host plus the attribution keys.