### PR TITLE
feat: pre-accept Claude Code startup prompts in containers

### DIFF
--- a/src/container-injections/attention-hooks.ts
+++ b/src/container-injections/attention-hooks.ts
@@ -1,5 +1,5 @@
 import { PORT } from '../lib/config.server.ts';
-import { checkPresence, execInContainer } from '../lib/exec.server.ts';
+import { checkPresence, execInContainer, mergeJsonFileScript } from '../lib/exec.server.ts';
 import type { ContainerTarget, Injection } from '../lib/injections.server.ts';
 
 function bridgeUrl(): string {
@@ -65,13 +65,8 @@ async function writeBridgeHeader(
 
 /** Merging rather than overwriting is what lets the settings.json injections compose in any order. */
 export function mergeClaudeSettingsScript(): string {
-	return (
-		'h=$(eval echo ~$(id -un)); d="${CLAUDE_CONFIG_DIR:-$h/.claude}"; mkdir -p "$d"; ' +
-		'f="$d/settings.json"; new="$CODEBAY_STDIN"; ' +
-		'if command -v jq >/dev/null 2>&1 && [ -s "$f" ] && ' +
-		'merged=$(printf \'%s\' "$new" | jq -s \'.[0] * .[1]\' "$f" - 2>/dev/null); then ' +
-		'printf \'%s\' "$merged" > "$f"; else printf \'%s\' "$new" > "$f"; fi; ' +
-		'chmod 644 "$f"'
+	return mergeJsonFileScript(
+		'h=$(eval echo ~$(id -un)); d="${CLAUDE_CONFIG_DIR:-$h/.claude}"; mkdir -p "$d"; f="$d/settings.json"; '
 	);
 }
 

--- a/src/container-injections/claude-trust.ts
+++ b/src/container-injections/claude-trust.ts
@@ -1,0 +1,59 @@
+import { checkPresence, execInContainer, mergeJsonFileScript } from '../lib/exec.server.ts';
+import type { ContainerTarget, Injection } from '../lib/injections.server.ts';
+
+/**
+ * Pre-accepts the three prompts `claude` shows on first launch, so a throwaway instance
+ * opens straight into a session: the folder-trust dialog and the MCP-server approval
+ * (both per-project, keyed by the path `claude` runs in), and the one-time Bypass
+ * Permissions acknowledgement (`--dangerously-skip-permissions` still trips it without this).
+ * Key names verified against the shipped `claude` binary.
+ */
+export function claudeTrustConfig(workspacePath: string | null): Record<string, unknown> {
+	const cfg: Record<string, unknown> = {
+		// Idempotent with the credentials injection; keeps this self-sufficient when auth is skipped.
+		hasCompletedOnboarding: true,
+		bypassPermissionsModeAccepted: true
+	};
+	if (workspacePath) {
+		cfg.projects = {
+			[workspacePath]: {
+				hasTrustDialogAccepted: true,
+				hasCompletedProjectOnboarding: true,
+				enableAllProjectMcpServers: true
+			}
+		};
+	}
+	return cfg;
+}
+
+/** Same resolution the credentials injection uses, so both target the one `.claude.json`. */
+const CLAUDE_JSON_PATH_SETUP =
+	'h=$(eval echo ~$(id -un)); f="${CLAUDE_CONFIG_DIR:+$CLAUDE_CONFIG_DIR/.claude.json}"; f="${f:-$h/.claude.json}"; ';
+
+/** Safe here only because instances are throwaway, single-tenant sandboxes. */
+export const claudeTrust: Injection = {
+	id: 'claude-trust',
+	label: 'Claude trust & MCP auto-accept',
+
+	async apply(target, log) {
+		log('Pre-accepting Claude trust, MCP, and bypass-permissions prompts…\n');
+		const config = claudeTrustConfig(target.instance.remote_workspace_folder);
+		const res = await execInContainer(target, {
+			script: mergeJsonFileScript(CLAUDE_JSON_PATH_SETUP),
+			stdin: JSON.stringify(config)
+		});
+		log(
+			res.ok
+				? '✓ Claude startup prompts pre-accepted\n'
+				: `⚠ Claude trust injection failed: ${res.error}\n`
+		);
+	},
+
+	async check(target: ContainerTarget) {
+		return checkPresence(
+			target,
+			CLAUDE_JSON_PATH_SETUP +
+				'[ -s "$f" ] && grep -q bypassPermissionsModeAccepted "$f" && echo 1 || echo 0'
+		);
+	}
+};

--- a/src/container-injections/injections.isolated.test.ts
+++ b/src/container-injections/injections.isolated.test.ts
@@ -14,6 +14,7 @@ import { hostEnvVarPresence, hostEnvVarsConfig, parseHostEnvVarNames } from './h
 import { expandTilde, extractScriptPath } from './claude-statusline.ts';
 import { hostClaudeModel } from './claude-model.ts';
 import { NO_COAUTHOR_SETTINGS } from './claude-no-coauthor.ts';
+import { claudeTrustConfig } from './claude-trust.ts';
 import { homedir } from 'node:os';
 import { INSTALL_SCRIPT, TMUX_CONF_LINES } from './tmux.ts';
 
@@ -68,6 +69,13 @@ describe('injection registry', () => {
 		expect(noCoauthor).toBeDefined();
 		expect(typeof noCoauthor!.check).toBe('function');
 		expect(noCoauthor!.auth).toBeUndefined();
+	});
+
+	test('claude-trust is registered with a health check', () => {
+		const trust = injections.find((i) => i.id === 'claude-trust');
+		expect(trust).toBeDefined();
+		expect(typeof trust!.check).toBe('function');
+		expect(trust!.auth).toBeUndefined();
 	});
 
 	test('claude-statusline is registered with an auth chip and a health check', () => {
@@ -400,6 +408,29 @@ describe('NO_COAUTHOR_SETTINGS', () => {
 			commit: '',
 			pr: '',
 			includeCoAuthoredBy: false
+		});
+	});
+});
+
+describe('claudeTrustConfig', () => {
+	test('always pre-accepts onboarding and the bypass-permissions warning at root', () => {
+		const cfg = claudeTrustConfig(null);
+		expect(cfg.hasCompletedOnboarding).toBe(true);
+		expect(cfg.bypassPermissionsModeAccepted).toBe(true);
+	});
+
+	test('omits the projects block when no workspace path is known', () => {
+		expect(claudeTrustConfig(null).projects).toBeUndefined();
+	});
+
+	test('nests trust + MCP auto-accept under the workspace path', () => {
+		const cfg = claudeTrustConfig('/workspaces/my-repo');
+		expect(cfg.projects).toEqual({
+			'/workspaces/my-repo': {
+				hasTrustDialogAccepted: true,
+				hasCompletedProjectOnboarding: true,
+				enableAllProjectMcpServers: true
+			}
 		});
 	});
 });

--- a/src/lib/exec.server.ts
+++ b/src/lib/exec.server.ts
@@ -90,3 +90,21 @@ export function writeSecretFileScript(dirExpr: string, filename: string, mode = 
 	const path = `${dirExpr}/${filename}`;
 	return `mkdir -p "${dirExpr}"; printf '%s' "$CODEBAY_STDIN" > "${path}"; chmod ${mode} "${path}";`;
 }
+
+/**
+ * Deep-merges the JSON in `$CODEBAY_STDIN` into a target file, letting settings injections
+ * compose in any order. `pathSetup` is a shell snippet that must set `f` to the target path
+ * (and create its directory); `jq '.[0] * .[1]'` recurses into nested objects, so keys like
+ * `projects.<path>` merge rather than clobber. Falls back to a plain write when the file is
+ * missing/empty or jq is unavailable.
+ */
+export function mergeJsonFileScript(pathSetup: string): string {
+	return (
+		pathSetup +
+		'new="$CODEBAY_STDIN"; ' +
+		'if command -v jq >/dev/null 2>&1 && [ -s "$f" ] && ' +
+		'merged=$(printf \'%s\' "$new" | jq -s \'.[0] * .[1]\' "$f" - 2>/dev/null); then ' +
+		'printf \'%s\' "$merged" > "$f"; else printf \'%s\' "$new" > "$f"; fi; ' +
+		'chmod 644 "$f"'
+	);
+}

--- a/src/lib/injections.server.ts
+++ b/src/lib/injections.server.ts
@@ -12,6 +12,7 @@ import { attentionHooks } from '../container-injections/attention-hooks.ts';
 import { claudeStatusline } from '../container-injections/claude-statusline.ts';
 import { claudeModel } from '../container-injections/claude-model.ts';
 import { claudeSkipPermissions } from '../container-injections/claude-skip-permissions.ts';
+import { claudeTrust } from '../container-injections/claude-trust.ts';
 import { claudeAliases } from '../container-injections/claude-aliases.ts';
 import { claudeNoCoauthor } from '../container-injections/claude-no-coauthor.ts';
 import { hostEnvVars } from '../container-injections/host-env-vars.ts';
@@ -57,6 +58,7 @@ const BASE_INJECTIONS_TAIL: Injection[] = [
 	claudeStatusline,
 	claudeModel,
 	claudeSkipPermissions,
+	claudeTrust,
 	claudeAliases,
 	claudeNoCoauthor,
 	hostEnvVars

--- a/src/lib/instances.server.ts
+++ b/src/lib/instances.server.ts
@@ -321,6 +321,13 @@ async function provision(row: InstanceRow, opts: { noCache?: boolean } = {}): Pr
 			error: null
 		});
 
+		// updateInstance writes the DB, not `row`; mirror the fields so `target.instance`
+		// (e.g. remote_workspace_folder, which claude-trust keys on) isn't the stale pre-boot row.
+		row.container_id = result.containerId;
+		row.remote_workspace_folder = result.remoteWorkspaceFolder ?? null;
+		row.remote_user = result.remoteUser ?? null;
+		row.status = 'running';
+
 		const target = {
 			containerId: result.containerId,
 			remoteUser: result.remoteUser,


### PR DESCRIPTION
## What & why

When an instance's IDE opens, the injected Terminal task launches `claude --dangerously-skip-permissions`, which greets the user with three first-run prompts. In a throwaway, single-tenant sandbox that already injects credentials and auto-skips permissions, these add friction with no safety benefit:

1. **Folder trust** — "Quick safety check: Is this a project you created or one you trust?"
2. **MCP trust** — "MCP servers may execute code or access system resources." (when the project ships a `.mcp.json`)
3. **Bypass Permissions warning** — "WARNING: Claude Code running in Bypass Permissions mode." (`--dangerously-skip-permissions` trips this on first run)

`--dangerously-skip-permissions` alone does **not** suppress #1 or #2 — they're independent gates.

## Approach

New `claude-trust` injection merges the pre-accept keys into the container's `~/.claude.json`:

- root `bypassPermissionsModeAccepted: true` → #3
- per-project `hasTrustDialogAccepted` + `hasCompletedProjectOnboarding` → #1
- per-project `enableAllProjectMcpServers: true` → #2 (auto-approves all project MCP servers without needing their names)

The project key is the container workspace path (`remote_workspace_folder`), i.e. the path `claude` runs in. Every key was verified against the shipped `claude` binary and a live `.claude.json`, not from docs (which don't cover them).

### Supporting changes
- Extracted the jq deep-merge into a reusable `mergeJsonFileScript(pathSetup)` helper in `exec.server.ts`; `mergeClaudeSettingsScript` now delegates to it (no behavior change). The deep-merge (`jq '.[0] * .[1]'`) layers on top of the credentials injection's `{"hasCompletedOnboarding":true}` and falls back to a plain write when the file/jq is absent.
- Mirror `container_id` / `remote_workspace_folder` / `remote_user` / `status` onto the in-memory `row` after `devcontainerUp`, so `target.instance` isn't the stale pre-boot row (the trust config keys on `remote_workspace_folder`).

## Out of scope

The code-server "insecure context" modal — code-server exposes no setting/flag for it; it's a browser-triggered notice shown only over http on a non-localhost host (LAN IP, `--network host`). On `http://localhost` it never appears. Hiding it would need proxy HTML/CSP surgery not worth the fragility.

## Testing

- `bun run checks` passes: 167 tests, 0 failures, clean typecheck.
- Added registry test + `claudeTrustConfig` unit tests.
- Validated the deep-merge shell logic against a simulated `.claude.json` (preserves `hasCompletedOnboarding`, nests the project keys; fallback writes when no file exists).
- **Not yet run (needs Docker):** create an instance (ideally one with a `.mcp.json`), open its IDE, confirm `claude` launches prompt-free and the new "Claude trust & MCP auto-accept" health chip is green.