### PR TITLE
feat: warn before leaving the SPA when instances are running

### DIFF
--- a/src/components/AppShell.svelte
+++ b/src/components/AppShell.svelte
@@ -114,6 +114,19 @@
 		return () => window.removeEventListener('popstate', onPop);
 	});
 
+	// Native unsaved-changes guard: a reload/close/external-nav tears down the code-server
+	// iframes and loses in-editor state. In-app /↔/ide transitions are pushState (no unload)
+	// and Settings/Details links open in new tabs, so this only fires on a true teardown.
+	$effect(() => {
+		if (running.length === 0) return;
+		function onBeforeUnload(e: BeforeUnloadEvent) {
+			e.preventDefault();
+			e.returnValue = '';
+		}
+		window.addEventListener('beforeunload', onBeforeUnload);
+		return () => window.removeEventListener('beforeunload', onBeforeUnload);
+	});
+
 	// Mounted lazily, then kept mounted (hidden via CSS) so the editor survives tab switches.
 	const visited = new SvelteSet<string>();
 	$effect(() => {


### PR DESCRIPTION
## What

Adds a native "you'll lose your state if you leave" prompt (the standard unsaved-form `beforeunload` guard) when the user is in the SPA section (`/` or `/ide/:id`) and there's at least one **running** instance.

## Why

The running code-server editors live in `<iframe>`s that are mounted once and kept alive across in-app navigation. A genuine page teardown — reload, tab close, or address-bar/external navigation — destroys those iframes, losing in-editor state (unsaved buffers, terminal sessions/scrollback). This guards against that.

## How

A single `$effect` in `src/components/AppShell.svelte` (the persistent shell, mounted **only** on `/` and `/ide/:id`) registers a `beforeunload` listener, gated on `running.length > 0`:

- Reading the `running` `$derived` list makes the effect reactively add/remove the listener as instances start and stop.
- The scoping falls out for free: in-app `/`↔`/ide/:id` transitions use `history.pushState` (no unload), and every link to a non-SPA page (`/settings`, `/instances/:id`) opens in a new tab (`target="_blank"` via `withPopupMarker`). So the shell page is never unloaded for intentional in-app navigation — the prompt only surfaces on a true teardown.

## Testing

- `bun run checks` — format + typecheck + all 164 tests pass.
- The native `beforeunload` dialog can't be asserted programmatically and triggering it live needs a running instance (Docker). Behavior to verify manually:
  - No running instances → reload: no prompt.
  - ≥1 running instance on `/` or `/ide/:id` → reload / close tab: native prompt.
  - Settings cog / Details (new tab) and tab-switching `/`↔`/ide/:id`: no prompt.