### PR TITLE
fix: auto-scroll boot log with a Follow toggle

### DIFF
--- a/src/components/InstanceView.svelte
+++ b/src/components/InstanceView.svelte
@@ -25,8 +25,7 @@
 	// Pin to the newest output whenever logs grow — but only while following.
 	// tick() lets the <pre> text node grow before we scroll, so we reach the true bottom.
 	$effect(() => {
-		logs; // track appended chunks
-		if (!following) return;
+		if (!following || logs.length === 0) return; // reading logs.length tracks appended chunks
 		tick().then(() => {
 			if (following) logEl?.scrollTo(0, logEl.scrollHeight);
 		});

--- a/src/components/InstanceView.svelte
+++ b/src/components/InstanceView.svelte
@@ -11,6 +11,7 @@
 	import { enhance } from 'mochi-framework';
 	import type { MochiEnhanceOptions } from 'mochi-framework';
 	import { onBackLinkClick, installPopupBackTrap } from '../lib/popup-nav.ts';
+	import { tick } from 'svelte';
 
 	let { id, injectionChecks = 0 }: { id: string; injectionChecks?: number } = $props();
 
@@ -18,11 +19,30 @@
 	let health = $state<InstanceHealth | null>(null);
 	let lastFetchedAt = $state<number | null>(null);
 	let logs = $state('');
+	let logEl = $state<HTMLDivElement | null>(null);
+	let following = $state(true);
 
-	// Runs after the DOM updates, so scrollHeight is fresh without a tick().
-	function autoscroll(node: HTMLDivElement) {
-		void logs; // the dependency this effect exists for
-		node.scrollTop = node.scrollHeight;
+	// Pin to the newest output whenever logs grow — but only while following.
+	// tick() lets the <pre> text node grow before we scroll, so we reach the true bottom.
+	$effect(() => {
+		logs; // track appended chunks
+		if (!following) return;
+		tick().then(() => {
+			if (following) logEl?.scrollTo(0, logEl.scrollHeight);
+		});
+	});
+
+	// A user scrolling up pauses following; programmatic scroll-to-bottom keeps the
+	// gap ~0, so it never trips this — only re-clicking "Follow log" resumes.
+	function onLogScroll() {
+		if (!logEl) return;
+		const gap = logEl.scrollHeight - logEl.clientHeight - logEl.scrollTop;
+		if (gap > 40) following = false;
+	}
+
+	function toggleFollow() {
+		following = !following;
+		if (following) logEl?.scrollTo(0, logEl.scrollHeight);
 	}
 
 	$effect(() => installPopupBackTrap());
@@ -234,11 +254,16 @@
 	<div class="logwrap panel">
 		<div class="log-bar panel-bar">
 			<span>Boot log</span>
-			<button class="copy" onclick={copyLogs} disabled={!logs}>
-				{copied ? 'Copied!' : 'Copy logs'}
-			</button>
+			<div class="log-actions">
+				<button class="copy" class:active={following} onclick={toggleFollow}>
+					{following ? 'Following' : 'Follow log'}
+				</button>
+				<button class="copy" onclick={copyLogs} disabled={!logs}>
+					{copied ? 'Copied!' : 'Copy logs'}
+				</button>
+			</div>
 		</div>
-		<div class="logs" {@attach autoscroll}>
+		<div class="logs" bind:this={logEl} onscroll={onLogScroll}>
 			<pre>{logs || 'Waiting for output…'}<span class="caret"></span></pre>
 		</div>
 		{#if instance?.status === 'error' && instance.error}
@@ -504,6 +529,11 @@
 		align-items: center;
 		justify-content: space-between;
 	}
+	.log-actions {
+		display: flex;
+		gap: 6px;
+		align-items: center;
+	}
 	.copy {
 		font-family: var(--font-mono);
 		font-weight: 600;
@@ -517,6 +547,10 @@
 		cursor: pointer;
 	}
 	.copy:hover:not(:disabled) {
+		background: transparent;
+		color: var(--bg);
+	}
+	.copy.active {
 		background: transparent;
 		color: var(--bg);
 	}


### PR DESCRIPTION
## What

The **Boot log** on the instance detail page wasn't scrolling to the newest line as `devcontainer up` streamed output.

The existing `autoscroll` attachment was fragile on two counts:
- It tracked reactivity via `void logs;` — a statement with no observable effect that a minifier can drop.
- It measured `node.scrollHeight` without waiting for the child `<pre>{logs}</pre>` text to grow, so the measurement was stale (the classic "measure before DOM update" trap).

## Change

Replaces the attachment with an explicit **follow model** (like CI log viewers):
- A `$effect` scrolls to the bottom whenever `logs` grow — after `tick()`, so the DOM has updated — but only while `following` is on.
- Scrolling up (gap > 40px from the bottom) pauses following. Programmatic scroll-to-bottom lands at gap ≈ 0, so it never self-trips.
- A new **"Follow log" / "Following"** toggle sits next to **Copy logs**; clicking it snaps to the bottom and resumes.

All confined to `src/components/InstanceView.svelte` (script, markup, styles). No server or WebSocket changes.

## Verification

- `bun run checks` green — format, typecheck (0 errors), 164 tests pass.
- Logic validated against the Svelte 5 docs (`$effect`/`tick()` autoscroll pattern) and `svelte-autofixer` (no issues).

_Manual boot check (needs a live Docker daemon): while **Following**, the log stays pinned to the newest line; scroll up → button flips to **Follow log** and the view stops jumping; click it → snaps to bottom and resumes._