### PR TITLE
chore: run eslint as part of bun run checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,15 +18,15 @@ bun run typecheck  # svelte-check (with a custom warning-ignore flag) + tsc --no
 bun test           # all tests
 bun test src/index.isolated.test.ts          # single file
 bun test -t "renders Hello world"            # single test by name
-bun run checks     # format + typecheck + tests — run this after every change (see below)
+bun run checks     # format + eslint + typecheck + tests — run this after every change (see below)
 bun run clean      # remove .mochi build output
-bun run lint       # prettier --check + eslint (read-only; `checks` runs format instead)
+bun run lint       # prettier --check + eslint (read-only; `checks` runs format instead of prettier --check, but the same eslint)
 bun run gen:chimes # re-render attention chimes to public/sounds/ WAVs (after editing scripts/gen-chimes.ts)
 bun run prod       # build + serve the production bundle
 bun run verify:package # pack the tarball, install + boot it elsewhere (see npm packaging below)
 ```
 
-**Always run `bun run checks` after implementing a change** (it runs `format`, then `typecheck`, then `test`) and fix anything it surfaces before considering the work done.
+**Always run `bun run checks` after implementing a change** (it runs `format`, then `eslint`, then `typecheck`, then `test`) and fix anything it surfaces before considering the work done.
 
 **Docker availability & testing strategy.** The automated suite (`bun test` / `bun run checks`) is fully self-contained — even `docker.isolated.test.ts` stubs dockerode via `globalThis.__codebayDocker`, so **no Docker daemon is required** and the checks always run (e.g. inside the Bun-only `.devcontainer/`, which deliberately has no Docker access). Only end-to-end verification of the instance lifecycle — actually creating an instance, `devcontainer up`, the boot/health flow — needs a **live daemon**. Before attempting any such live verification, probe with `docker info` (or `docker context inspect`): if it's unavailable, don't try to boot instances — say so and fall back to the unit/isolated tests, which cover the orchestration logic against stubs. When Docker _is_ running, live-boot verification becomes an option on top of the suite.
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		"test": "bun test",
 		"lint": "prettier --check . && eslint .",
 		"format": "prettier --write .",
-		"checks": "bun run format && bun run typecheck && bun run test",
+		"checks": "bun run format && eslint . && bun run typecheck && bun run test",
 		"clean": "rimraf .mochi",
 		"gen:chimes": "bun scripts/gen-chimes.ts",
 		"debug:tokens": "bun scripts/debug-tokens.ts",


### PR DESCRIPTION
## Why

CI runs eslint (via `bun run lint`), but `bun run checks` only ran `format` (prettier --write) — so an eslint-only error passes local `checks` and still fails CI. That's exactly what happened on #96.

## Change

- `checks` now runs `eslint .` after `format` (prettier is already covered by `format`):
  `bun run format && eslint . && bun run typecheck && bun run test`
- Updated CLAUDE.md's three descriptions of `checks` to say `format + eslint + typecheck + tests`.

## Verification

- `bun run checks` green (eslint included, 0 problems; 164 tests pass).