### PR TITLE
fix: wrap long instance names instead of truncating

### DIFF
--- a/src/components/InstanceCard.svelte
+++ b/src/components/InstanceCard.svelte
@@ -167,9 +167,7 @@
 		font-family: var(--font-mono);
 		font-weight: 600;
 		font-size: 15px;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
+		overflow-wrap: anywhere;
 		/* Reset button chrome so it reads as plain text until hovered. */
 		margin: 0;
 		padding: 2px 4px;

--- a/src/components/SettingsView.svelte
+++ b/src/components/SettingsView.svelte
@@ -878,8 +878,8 @@
 					<div class="text">
 						<div class="name">Rebuild running containers (no cache)</div>
 						<div class="desc">
-							Re-run <code>devcontainer up --build-no-cache</code> for every currently-running instance.
-							In-container edits are kept; stopped instances are left alone.
+							Rebuild every currently-running instance from scratch, without using any cached image
+							layers. In-container edits are kept; stopped instances are left alone.
 						</div>
 						{#if rebuildError}
 							<div class="msg error">{rebuildError}</div>


### PR DESCRIPTION
## What

In the instance cards, long names were truncated with an ellipsis, hiding part of the name. Now the name wraps onto multiple lines so the full name stays visible.

## How

Replaced `overflow: hidden; text-overflow: ellipsis; white-space: nowrap` on `.name` with `overflow-wrap: anywhere` so long names (including unbroken strings) wrap. The `card-head` flex row keeps `align-items: center`, so the avatar and status badge stay centered against the taller name block.

## Testing

`bun run checks` passes (format, eslint, typecheck, 168 tests).