### PR TITLE
fix: Claude trust pre-acceptance on claude ≥2.1.220 + injection/launch race

### DIFF
--- a/src/container-injections/claude-trust.ts
+++ b/src/container-injections/claude-trust.ts
@@ -1,5 +1,9 @@
 import { deepMerge, editJsonFile, readJsonFile } from '../lib/container-files.server.ts';
-import { CLAUDE_JSON_FILE } from '../lib/claude-settings.server.ts';
+import {
+	CLAUDE_JSON_FILE,
+	mergeClaudeSettings,
+	readClaudeSettings
+} from '../lib/claude-settings.server.ts';
 import type { Injection } from '../lib/injections.server.ts';
 
 /**
@@ -27,6 +31,11 @@ export function claudeTrustConfig(workspacePath: string | null): Record<string, 
 	return cfg;
 }
 
+/** claude ≥2.1.220 keeps the bypass acknowledgement here; the `.claude.json` key stays for older versions. */
+export const CLAUDE_TRUST_SETTINGS: Record<string, unknown> = {
+	skipDangerousModePermissionPrompt: true
+};
+
 /** Safe here only because instances are throwaway, single-tenant sandboxes. */
 export const claudeTrust: Injection = {
 	id: 'claude-trust',
@@ -38,15 +47,27 @@ export const claudeTrust: Injection = {
 		const res = await editJsonFile(target, CLAUDE_JSON_FILE, (cur) =>
 			deepMerge(cur, claudeTrustConfig(target.instance.remote_workspace_folder))
 		);
+		if (!res.ok) {
+			log(`⚠ Claude trust injection failed: ${res.error}\n`);
+			return;
+		}
+		const settings = await mergeClaudeSettings(target, CLAUDE_TRUST_SETTINGS);
 		log(
-			res.ok
+			settings.ok
 				? '✓ Claude startup prompts pre-accepted\n'
-				: `⚠ Claude trust injection failed: ${res.error}\n`
+				: `⚠ Claude trust injection failed: ${settings.error}\n`
 		);
 	},
 
+	// Not keyed on `.claude.json`'s `bypassPermissionsModeAccepted`: claude ≥2.1.220 drops
+	// that key (and `enableAllProjectMcpServers`) when it rewrites the file after startup.
 	async check(target) {
+		const settings = await readClaudeSettings(target);
+		if (settings?.skipDangerousModePermissionPrompt !== true) return false;
+		const workspace = target.instance.remote_workspace_folder;
+		if (!workspace) return true;
 		const cfg = await readJsonFile(target, CLAUDE_JSON_FILE);
-		return cfg?.bypassPermissionsModeAccepted === true;
+		const projects = cfg?.projects as Record<string, Record<string, unknown>> | undefined;
+		return projects?.[workspace]?.hasTrustDialogAccepted === true;
 	}
 };

--- a/src/container-injections/injections.isolated.test.ts
+++ b/src/container-injections/injections.isolated.test.ts
@@ -14,7 +14,7 @@ import { hostEnvVarPresence, hostEnvVarsConfig, parseHostEnvVarNames } from './h
 import { expandTilde, extractScriptPath } from './claude-statusline.ts';
 import { hostClaudeModel } from './claude-model.ts';
 import { NO_COAUTHOR_SETTINGS } from './claude-no-coauthor.ts';
-import { claudeTrustConfig } from './claude-trust.ts';
+import { claudeTrustConfig, CLAUDE_TRUST_SETTINGS } from './claude-trust.ts';
 import { homedir } from 'node:os';
 import { INSTALL_SCRIPT, TMUX_CONF_LINES } from './tmux.ts';
 
@@ -439,6 +439,10 @@ describe('claudeTrustConfig', () => {
 
 	test('omits the projects block when no workspace path is known', () => {
 		expect(claudeTrustConfig(null).projects).toBeUndefined();
+	});
+
+	test('pre-accepts the bypass warning in settings.json, where claude ≥2.1.220 keeps it', () => {
+		expect(CLAUDE_TRUST_SETTINGS).toEqual({ skipDangerousModePermissionPrompt: true });
 	});
 
 	test('nests trust + MCP auto-accept under the workspace path', () => {

--- a/src/lib/devcontainer.isolated.test.ts
+++ b/src/lib/devcontainer.isolated.test.ts
@@ -73,7 +73,7 @@ describe('writeOverrideConfig terminal task + settings', () => {
 		const terminal = readTasks().tasks.find((t: { label: string }) => t.label === 'Terminal');
 		// Create-or-attach: -A doubles as the run-once gate and reattaches the live
 		// session (Claude + scrollback) after the browser reaped the previous PTY.
-		expect(terminal.command).toContain("exec tmux new-session -A -s codebay 'claude");
+		expect(terminal.command).toContain("exec tmux new-session -A -s codebay '");
 		// Guarded on tmux actually being installed, and ordered before the fallback.
 		expect(terminal.command).toContain('command -v tmux');
 		expect(terminal.command.indexOf('tmux')).toBeLessThan(
@@ -81,6 +81,20 @@ describe('writeOverrideConfig terminal task + settings', () => {
 		);
 		// $SHELL must be left for tmux's sh -c, not VS Code's ${...} resolver.
 		expect(terminal.command).toContain('exec "$SHELL" -l');
+	});
+
+	test('holds claude until the injections-done sentinel appears, in both launch paths', async () => {
+		await writeOverrideConfig(dir, 8001);
+		const terminal = readTasks().tasks.find((t: { label: string }) => t.label === 'Terminal');
+		// A claude that starts mid-injection clobbers the trust keys on its next config rewrite.
+		const tmuxPath = terminal.command.split('.codebay-terminal-launched')[0];
+		const fallbackPath = terminal.command.split('.codebay-terminal-launched')[1];
+		for (const path of [tmuxPath, fallbackPath]) {
+			expect(path).toContain('.codebay-injections-done');
+			expect(path.indexOf('.codebay-injections-done')).toBeLessThan(path.indexOf('claude'));
+		}
+		// Bounded: a boot that never writes the sentinel must still yield a terminal.
+		expect(terminal.command).toContain('-ge 60');
 	});
 
 	test('falls back to the first-open marker gate when tmux is missing', async () => {

--- a/src/lib/devcontainer.server.ts
+++ b/src/lib/devcontainer.server.ts
@@ -78,6 +78,18 @@ const CODE_SERVER_SETTINGS = {
 
 const TMUX_SESSION = 'codebay';
 
+/** Written to `$HOME` when the post-up injection sequence finishes; the terminal launcher waits on it. */
+export const INJECTIONS_DONE_FILE = '.codebay-injections-done';
+
+/**
+ * An auto-launched `claude` that starts mid-injection reads `~/.claude.json` before the trust
+ * keys land and clobbers them on its next rewrite, so hold it until the sentinel appears.
+ * Bounded so a failed boot (sentinel never written) still yields a usable terminal.
+ */
+const WAIT_FOR_INJECTIONS =
+	`[ -e "$HOME/${INJECTIONS_DONE_FILE}" ] || echo "Waiting for codebay setup to finish…"; ` +
+	`i=0; until [ -e "$HOME/${INJECTIONS_DONE_FILE}" ] || [ "$i" -ge 60 ]; do sleep 1; i=$((i + 1)); done; `;
+
 /**
  * Runs under tmux so Claude survives the browser closing — code-server reaps the
  * detached PTY, which only kills the tmux client. `-A` doubles as the run-once gate.
@@ -87,9 +99,10 @@ const TERMINAL_TASK = {
 	type: 'shell',
 	command:
 		// `"$SHELL"` must reach tmux unexpanded; VS Code would substitute a `${…}` form first.
-		`if command -v tmux >/dev/null 2>&1; then exec tmux new-session -A -s ${TMUX_SESSION} 'claude --dangerously-skip-permissions; exec "$SHELL" -l'; fi; ` +
+		`if command -v tmux >/dev/null 2>&1; then exec tmux new-session -A -s ${TMUX_SESSION} '${WAIT_FOR_INJECTIONS}claude --dangerously-skip-permissions; exec "$SHELL" -l'; fi; ` +
 		// Without tmux there's no run-once gate, and folderOpen re-fires on every workspace load.
 		'MARK="$HOME/.codebay-terminal-launched"; [ -e "$MARK" ] && exit 0; touch "$MARK"; ' +
+		WAIT_FOR_INJECTIONS +
 		'claude --dangerously-skip-permissions; exec ${env:SHELL} -l',
 	presentation: { reveal: 'always', panel: 'shared', focus: true },
 	runOptions: { runOn: 'folderOpen' },

--- a/src/lib/instances.server.ts
+++ b/src/lib/instances.server.ts
@@ -38,9 +38,11 @@ import {
 	copyWorkspace,
 	devcontainerCliAvailable,
 	devcontainerUp,
+	INJECTIONS_DONE_FILE,
 	readDeclaredContainerPorts,
 	writeOverrideConfig
 } from './devcontainer.server.ts';
+import { writeContainerFile } from './container-files.server.ts';
 import { clearAttention, getAttention } from './bridge.server.ts';
 import { proxyPathFor } from './proxy.server.ts';
 import { resolveInjections } from './injections.server.ts';
@@ -341,6 +343,11 @@ async function provision(row: InstanceRow, opts: { noCache?: boolean } = {}): Pr
 				appendLog(row.id, `⚠ ${injection.label} injection failed: ${(err as Error).message}\n`);
 			}
 		}
+
+		// Unblocks the terminal launcher's wait; written even after ⚠s — its timeout is the fallback.
+		await writeContainerFile(target, { dir: '$HOME', name: INJECTIONS_DONE_FILE }, 'done\n').catch(
+			() => undefined
+		);
 
 		appendLog(row.id, `\n✓ Instance running — open it via the proxy at ${proxyPathFor(row.id)}\n`);
 		triggerReconcile();


### PR DESCRIPTION
## Problem

The **Claude trust & MCP auto-accept** health row flaked to `—` on some instances (#see boot logs showing ✓ yet the effect missing). Two causes, verified against live containers:

1. **claude ≥2.1.220 config drift** — claude rewrites `~/.claude.json` after startup and drops `bypassPermissionsModeAccepted` / `enableAllProjectMcpServers`; the bypass acknowledgement now lives in `~/.claude/settings.json` as `skipDangerousModePermissionPrompt`. Our health check keyed on the dropped key, so it flipped to `—` as soon as claude ran once.
2. **Launch race** — the auto-launched terminal (`tmux … claude --dangerously-skip-permissions`) can start claude while the post-up injections are still applying. claude then reads `.claude.json` before the trust keys land and clobbers them on its next rewrite (confirmed by mtimes: claude firstStartTime mid-injection-sequence, final `.claude.json` write missing our keys).

## Fix

- `claude-trust.apply()` also merges `skipDangerousModePermissionPrompt: true` into settings.json (legacy `.claude.json` keys kept for older claude); `check()` now keys on values that survive claude's rewrite (settings key + the project's `hasTrustDialogAccepted`).
- The manager writes a `$HOME/.codebay-injections-done` sentinel after the injection loop; the terminal launcher (both tmux and fallback paths) waits for it before starting claude, bounded at 60s so a failed boot still yields a usable terminal.

Only affects newly created instances (existing containers keep their old `tasks.json`).

## Testing

- `bun run checks` green (199 tests); new tests for the sentinel wait in both launcher paths and the settings.json trust patch.
- Verified against live containers that the new check() passes on a container where claude has already rewritten its config.