### PR TITLE
feat: loading state for instance-card actions

### DIFF
--- a/src/components/DashboardView.svelte
+++ b/src/components/DashboardView.svelte
@@ -16,13 +16,31 @@
 		pet
 	}: { preflight: Preflight; instances: Instance[]; loaded: boolean; pet?: AvatarArt } = $props();
 
+	type Action = 'start' | 'stop' | 'delete' | 'rebuild';
+
 	let browserOpen = $state(false);
 	let creating = $state(false);
 	let actionError = $state<string | null>(null);
 	let editingId = $state<string | null>(null);
 	let editingName = $state('');
+	// Per-instance in-flight action + the status it started from, so the busy overlay clears
+	// only once the live stream reports the resulting change (avoids flicker on the round-trip).
+	let pending = $state<Record<string, { action: Action; since: Instance['status'] }>>({});
 
 	const ready = $derived(preflight.docker && preflight.cli);
+
+	// Drop a pending entry once its instance is gone (deleted) or its status has moved on.
+	$effect(() => {
+		for (const [id, { since }] of Object.entries(pending)) {
+			const instance = instances.find((i) => i.id === id);
+			if (!instance || instance.status !== since) clearPending(id);
+		}
+	});
+
+	function clearPending(id: string) {
+		const { [id]: _, ...rest } = pending;
+		pending = rest;
+	}
 
 	async function createFrom(sourcePath: string, opts?: { branch?: string }) {
 		browserOpen = false;
@@ -42,7 +60,7 @@
 		}
 	}
 
-	async function act(id: string, action: 'start' | 'stop' | 'delete' | 'rebuild') {
+	async function act(id: string, action: Action) {
 		actionError = null;
 		if (action === 'delete' && !confirm('Delete this instance and its copied files?')) return;
 		// Rebuild discards the container; the workspace copy lives on the host and survives.
@@ -51,11 +69,14 @@
 			!confirm('Recreate this container and re-run setup? The workspace is kept.')
 		)
 			return;
+		const since = instances.find((i) => i.id === id)?.status;
+		if (since) pending = { ...pending, [id]: { action, since } };
 		try {
 			await apiPost(`/api/instances/${id}/${action}`, undefined, `Failed to ${action}`);
-			// The live stream reflects the resulting state.
+			// The live stream reflects the resulting state; the $effect clears the busy overlay.
 		} catch (err) {
 			actionError = (err as Error).message;
+			clearPending(id);
 		}
 	}
 
@@ -138,6 +159,7 @@
 				<InstanceCard
 					{instance}
 					editing={editingId === instance.id}
+					pending={pending[instance.id]?.action ?? null}
 					bind:editingName
 					onact={(action) => act(instance.id, action)}
 					onstartrename={() => startRename(instance)}

--- a/src/components/InstanceCard.svelte
+++ b/src/components/InstanceCard.svelte
@@ -7,10 +7,13 @@
 	import Button from './Button.svelte';
 	import { withPopupMarker } from '../lib/popup-nav.ts';
 
+	type Action = 'start' | 'stop' | 'delete' | 'rebuild';
+
 	let {
 		instance,
 		editing,
 		editingName = $bindable(),
+		pending = null,
 		onact,
 		onstartrename,
 		oncommitrename,
@@ -19,7 +22,9 @@
 		instance: Instance;
 		editing: boolean;
 		editingName: string;
-		onact: (action: 'start' | 'stop' | 'delete' | 'rebuild') => void;
+		/** The user-triggered action currently in flight, if any — drives the busy overlay. */
+		pending?: Action | null;
+		onact: (action: Action) => void;
 		onstartrename: () => void;
 		oncommitrename: () => void;
 		oncancelrename: () => void;
@@ -31,9 +36,19 @@
 			instance.status === 'stopped' ||
 			(instance.status === 'error' && !!instance.container_id)
 	);
+
+	const BUSY_LABEL: Record<Action, string> = {
+		start: 'Starting…',
+		stop: 'Stopping…',
+		delete: 'Deleting…',
+		rebuild: 'Rebuilding…'
+	};
 </script>
 
-<li class="card panel">
+<li class="card panel" class:busy={!!pending} aria-busy={!!pending || undefined}>
+	{#if pending}
+		<div class="busy" aria-live="polite"><span class="busy-label">{BUSY_LABEL[pending]}</span></div>
+	{/if}
 	<div class="card-head">
 		<Avatar id={instance.id} name={instance.name} interactive />
 		{#if editing}
@@ -109,15 +124,49 @@
 
 <style>
 	.card {
+		position: relative;
 		background: var(--bg-card);
 		padding: 16px 16px 14px;
 		transition:
 			transform 0.08s steps(2),
 			box-shadow 0.08s steps(2);
 	}
-	.card:hover {
+	.card:hover:not(.busy) {
 		transform: translate(-1px, -1px);
 		box-shadow: 6px 6px 0 var(--ink);
+	}
+	/* Translucent scrim dims the card body and blocks clicks on the buttons beneath. */
+	.busy {
+		position: absolute;
+		inset: 0;
+		z-index: 1;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: color-mix(in srgb, var(--bg-card) 78%, transparent);
+	}
+	.busy-label {
+		font-family: var(--font-mono);
+		font-weight: 600;
+		font-size: 12px;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		padding: 4px 9px;
+		border: 1px solid var(--ink);
+		background: var(--ink);
+		color: var(--bg);
+		animation: lcd-blink 1.1s steps(1) infinite;
+	}
+	@keyframes lcd-blink {
+		50% {
+			background: transparent;
+			color: var(--ink);
+		}
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.busy-label {
+			animation: none;
+		}
 	}
 	.card-head {
 		display: flex;


### PR DESCRIPTION
## What

Adds a visible per-card busy state for the **Stop / Start / Delete / Rebuild** actions on the dashboard instance cards.

## Why

Clicking one of these actions fired `apiPost(...)` and then just waited for the live WebSocket stream to deliver the new status. The server does the real container work (`stopContainer` / `removeContainer`, several seconds) *before* returning, and there is no transitional status in the model — so for that whole window the card looked completely inert. The user had no way to tell their click registered.

## How

- **`DashboardView.svelte`** — tracks the in-flight action per instance (client-side), recording the status it started from. A `$effect` clears the entry once the live stream reports the instance is gone (delete) or its status changed, so the overlay clears exactly when the real state lands (no flicker back to the old buttons on the round-trip). Clears immediately on request error.
- **`InstanceCard.svelte`** — when an action is pending, renders a translucent scrim that dims the card body and a blinking LCD-style label (`Stopping…` / `Starting…` / `Deleting…` / `Rebuilding…`). The overlay covers the card so it also blocks further clicks — no need to disable each button. Hover-lift is suppressed while busy, and the pulse respects `prefers-reduced-motion`.

No server change and no new status enum value — the overlay is a thin client-only layer over the existing four statuses. Rebuild flips to `creating` almost instantly, so its overlay hands off cleanly to the existing "Booting…" badge.

## Testing

- `bun run checks` passes (format + eslint + typecheck + 199 tests).
- Live boot verification not run: no Docker daemon in this Bun-only devcontainer (`docker info` unavailable), which is expected per the repo's testing notes. The change is client-only UI over the existing stream.