### PR TITLE
fix: force code-server to always render dark theme

### DIFF
--- a/src/index.isolated.test.ts
+++ b/src/index.isolated.test.ts
@@ -4,9 +4,18 @@ import path from 'node:path';
 import type { Server } from 'bun';
 import { Mochi } from 'mochi-framework';
 import { themeHandle } from './lib/theme.server.ts';
+import { PROXY_PREFIX } from './lib/proxy.server.ts';
 
+// Stands in for a proxied code-server document: text/html that themeHandle must not rewrite.
+const proxyPath = `${PROXY_PREFIX}/test/page`;
 const routes = {
-	'/': Mochi.page('./src/__fixtures__/HelloWorld.svelte')
+	'/': Mochi.page('./src/__fixtures__/HelloWorld.svelte'),
+	[proxyPath]: Mochi.api(
+		() =>
+			new Response('<html lang="en">proxied</html>', {
+				headers: { 'Content-Type': 'text/html' }
+			})
+	)
 };
 
 // Mochi.serve() is a process-wide singleton (see mochiConfig.ts), so every
@@ -55,5 +64,10 @@ describe('minimal app', () => {
 	test('GET / renders data-theme="dark" when the theme cookie is dark', async () => {
 		const res = await fetch(base, { headers: { Cookie: 'theme=dark' } });
 		expect(await res.text()).toContain('<html data-theme="dark"');
+	});
+
+	test('leaves proxied code-server HTML untouched even with a theme cookie', async () => {
+		const res = await fetch(`${base}${proxyPath}`, { headers: { Cookie: 'theme=dark' } });
+		expect(await res.text()).not.toContain('data-theme');
 	});
 });

--- a/src/lib/devcontainer.isolated.test.ts
+++ b/src/lib/devcontainer.isolated.test.ts
@@ -116,6 +116,15 @@ describe('writeOverrideConfig terminal task + settings', () => {
 		expect(readSettings()['security.workspace.trust.enabled']).toBe(false);
 	});
 
+	test('pins a dark theme and disables auto color-scheme detection', async () => {
+		await writeOverrideConfig(dir, 8001);
+		const settings = readSettings();
+		expect(settings['window.autoDetectColorScheme']).toBe(false);
+		expect(settings['window.autoDetectHighContrast']).toBe(false);
+		expect(settings['workbench.preferredDarkColorTheme']).toBe('Default Dark Modern');
+		expect(settings['workbench.preferredLightColorTheme']).toBe('Default Dark Modern');
+	});
+
 	test('preserves an existing unrelated task and appends Terminal', async () => {
 		mkdirSync(join(dir, '.vscode'), { recursive: true });
 		writeFileSync(

--- a/src/lib/devcontainer.server.ts
+++ b/src/lib/devcontainer.server.ts
@@ -62,6 +62,13 @@ const EXCLUDE_MARKER_END = '# <<< codebay <<<';
 
 const CODE_SERVER_SETTINGS = {
 	'workbench.colorTheme': 'Default Dark Modern',
+	// Stop VS Code re-resolving the theme from the OS/browser color scheme at runtime —
+	// that re-resolution (fired on focus/tab-switch) is what randomly flips the editor to
+	// light. Pinning both preferred themes to dark keeps either branch dark even if it does.
+	'window.autoDetectColorScheme': false,
+	'window.autoDetectHighContrast': false,
+	'workbench.preferredDarkColorTheme': 'Default Dark Modern',
+	'workbench.preferredLightColorTheme': 'Default Dark Modern',
 	'workbench.secondarySideBar.defaultVisibility': 'hidden',
 	'chat.commandCenter.enabled': false,
 	// Instances are throwaway sandboxes — never nag to install recommended extensions.

--- a/src/lib/theme.server.ts
+++ b/src/lib/theme.server.ts
@@ -1,4 +1,5 @@
 import { getRequestContext, type Handle } from 'mochi-framework';
+import { PROXY_PREFIX } from './proxy.server.ts';
 
 /** Anything but an explicit choice is left untouched, so the CSS falls through to `prefers-color-scheme`. */
 export function injectThemeAttribute(html: string, cookieValue: string | undefined): string {
@@ -11,12 +12,15 @@ export const themeHandle: Handle = ({ event, resolve }) =>
 	resolve(event, {
 		transformPage: ({ html }) => {
 			// Mochi's fetch-fallback path also lands here, and it runs outside requestContext.
-			let cookieValue: string | undefined;
+			let ctx: ReturnType<typeof getRequestContext>;
 			try {
-				cookieValue = getRequestContext().cookies.get('theme');
+				ctx = getRequestContext();
 			} catch {
 				return html;
 			}
-			return injectThemeAttribute(html, cookieValue);
+			// `data-theme` is only meaningful to Codebay's own stylesheet; injecting it into a
+			// proxied code-server document would rewrite HTML that isn't ours, so leave it alone.
+			if (ctx.url.pathname.startsWith(PROXY_PREFIX + '/')) return html;
+			return injectThemeAttribute(html, ctx.cookies.get('theme'));
 		}
 	});


### PR DESCRIPTION
## Problem

VS Code (code-server) inside a Codebay IDE tab **randomly flips to light mode** when switching to that tab — no consistent trigger.

## Root cause

Each instance's code-server settings pinned only `workbench.colorTheme: "Default Dark Modern"`, but never disabled VS Code's auto color-scheme detection or pinned the preferred dark/light themes. VS Code Web re-resolves its theme at runtime (on window focus / `prefers-color-scheme` changes — all triggerable by a tab switch). Because Codebay keeps the IDE iframe mounted and only toggles CSS visibility (`AppShell.svelte` — panes are always mounted, only hidden), no document reload re-applies `colorTheme`, so a runtime re-resolution can settle on the built-in **light** theme. That matches the "random, on tab-switch" symptom.

## Fix

**Primary** — harden `CODE_SERVER_SETTINGS` (`src/lib/devcontainer.server.ts`) so light is unreachable no matter which path VS Code takes:
- `window.autoDetectColorScheme: false`
- `window.autoDetectHighContrast: false`
- `workbench.preferredDarkColorTheme` / `workbench.preferredLightColorTheme` both `Default Dark Modern`

**Secondary (correctness)** — stop the global `themeHandle` (`src/lib/theme.server.ts`) from rewriting **proxied** code-server HTML. Its `data-theme` injection is only meaningful to Codebay's own stylesheet; it now skips the `PROXY_PREFIX`, mirroring the existing special-casing in `index.ts` filters. Not the cause of this symptom, but the app's theme cookie has no business rewriting code-server's document.

## Tests

- `devcontainer.isolated.test.ts`: asserts the four new keys land in the staged code-server settings.
- `index.isolated.test.ts`: asserts `themeHandle` leaves a proxied `text/html` response untouched even with a `theme` cookie.

`bun run checks` passes (201 tests).

## Note

Already-running instances pick up the new settings only after code-server re-copies the file on (re)start; a code-server tab already open in the browser may keep its cached theme until reloaded. New instances get it immediately.