### PR TITLE
feat: add instance view filter (All | Active | Stopped) to dashboard

### DIFF
--- a/src/components/DashboardView.svelte
+++ b/src/components/DashboardView.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { type Instance, type Preflight } from '../types.ts';
+	import { type Instance, type InstanceFilter, type Preflight } from '../types.ts';
 	import type { AvatarArt } from '../avatars/index.ts';
 	import FolderBrowser from './FolderBrowser.svelte';
 	import InstanceCard from './InstanceCard.svelte';
@@ -19,6 +19,7 @@
 	type Action = 'start' | 'stop' | 'delete' | 'rebuild';
 
 	let browserOpen = $state(false);
+	let filter = $state<InstanceFilter>('all');
 	let creating = $state(false);
 	let actionError = $state<string | null>(null);
 	let editingId = $state<string | null>(null);
@@ -28,6 +29,14 @@
 	let pending = $state<Record<string, { action: Action; since: Instance['status'] }>>({});
 
 	const ready = $derived(preflight.docker && preflight.cli);
+
+	const visible = $derived(
+		instances.filter((i) => {
+			if (filter === 'active') return i.status === 'running' || i.status === 'creating';
+			if (filter === 'stopped') return i.status === 'stopped' || i.status === 'error';
+			return true;
+		})
+	);
 
 	// Drop a pending entry once its instance is gone (deleted) or its status has moved on.
 	$effect(() => {
@@ -126,6 +135,8 @@
 	canDelete={instances.length > 0}
 	{ready}
 	{creating}
+	{filter}
+	onFilter={(v) => (filter = v)}
 	onNew={() => (browserOpen = true)}
 	onDeleteAll={deleteAll}
 />
@@ -153,9 +164,11 @@
 				New instance
 			</Button>
 		</div>
+	{:else if visible.length === 0}
+		<div class="empty"><p class="empty-sub">No {filter} instances.</p></div>
 	{:else}
 		<ul class="grid">
-			{#each instances as instance (instance.id)}
+			{#each visible as instance (instance.id)}
 				<InstanceCard
 					{instance}
 					editing={editingId === instance.id}

--- a/src/components/InstanceFilter.svelte
+++ b/src/components/InstanceFilter.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+	import type { InstanceFilter } from '../types.ts';
+
+	let { value, onchange }: { value: InstanceFilter; onchange: (v: InstanceFilter) => void } =
+		$props();
+
+	const options: { value: InstanceFilter; label: string }[] = [
+		{ value: 'all', label: 'All' },
+		{ value: 'active', label: 'Active' },
+		{ value: 'stopped', label: 'Stopped' }
+	];
+</script>
+
+<div class="picker" role="radiogroup" aria-label="Filter instances">
+	{#each options as opt (opt.value)}
+		<button
+			type="button"
+			class="segment"
+			class:active={value === opt.value}
+			role="radio"
+			aria-checked={value === opt.value}
+			onclick={() => onchange(opt.value)}
+		>
+			{opt.label}
+		</button>
+	{/each}
+</div>
+
+<style>
+	.picker {
+		display: inline-flex;
+		flex: none;
+		border: 1px solid var(--ink);
+		background: var(--bg-card);
+	}
+	.segment {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		padding: 7px 12px;
+		font-family: var(--font-mono);
+		font-weight: 600;
+		font-size: 12px;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		border: none;
+		background: transparent;
+		color: var(--ink);
+		cursor: pointer;
+	}
+	.segment + .segment {
+		border-left: 1px solid var(--ink);
+	}
+	.segment:hover:not(.active) {
+		background: var(--ink);
+		color: var(--bg);
+	}
+	.segment.active {
+		font-weight: 700;
+		background: var(--ink);
+		color: var(--bg);
+		cursor: default;
+	}
+	.segment:focus-visible {
+		outline: 2px solid var(--ink);
+		outline-offset: -2px;
+	}
+</style>

--- a/src/components/TopBar.svelte
+++ b/src/components/TopBar.svelte
@@ -2,9 +2,10 @@
 	import Plus from '@lucide/svelte/icons/plus';
 	import Component from '@lucide/svelte/icons/component';
 	import { isDev } from 'mochi-framework';
-	import type { AuthProvider } from '../types.ts';
+	import type { AuthProvider, InstanceFilter } from '../types.ts';
 	import type { AvatarArt } from '../avatars/index.ts';
 	import Brand from './Brand.svelte';
+	import InstanceFilterControl from './InstanceFilter.svelte';
 	import SettingsCog from './SettingsCog.svelte';
 	import CredMenu from './CredMenu.svelte';
 	import Button from './Button.svelte';
@@ -16,6 +17,8 @@
 		canDelete = false,
 		ready = true,
 		creating = false,
+		filter,
+		onFilter,
 		onNew,
 		onDeleteAll
 	}: {
@@ -24,6 +27,8 @@
 		canDelete?: boolean;
 		ready?: boolean;
 		creating?: boolean;
+		filter?: InstanceFilter;
+		onFilter?: (v: InstanceFilter) => void;
 		onNew?: () => void;
 		onDeleteAll?: () => void;
 	} = $props();
@@ -34,6 +39,9 @@
 	<div class="topbar-actions">
 		{#if isDev}
 			<Button variant="default" size="sm" icon={Component} href="/debug">Debug</Button>
+		{/if}
+		{#if filter && onFilter}
+			<InstanceFilterControl value={filter} onchange={onFilter} />
 		{/if}
 		<SettingsCog />
 		<CredMenu {auth} />

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,9 @@ export interface Instance {
 	forwarded_ports: PortForward[];
 }
 
+/** Dashboard run-state view filter: All | Active (running/creating) | Stopped (stopped/error). */
+export type InstanceFilter = 'all' | 'active' | 'stopped';
+
 /** Live only — never persisted, so it always reflects the most recent probe. */
 export interface InstanceHealth {
 	containerRunning: boolean;


### PR DESCRIPTION
## What

Adds a small segmented control to the dashboard header — directly left of the settings gear — to filter the instance grid by run state:

**All** (default) · **Active** · **Stopped**

## Mapping

The filter is a client-only, in-memory view over the already-hydrated instance list — no server, DB, or WebSocket changes.

| Filter | Shows |
| --- | --- |
| All | every instance |
| Active | `running` + `creating` (up or coming up) |
| Stopped | `stopped` + `error` (down / failed) |

The choice is not persisted, so the dashboard always opens on **All**. When a filter matches nothing (but instances exist), a "No <filter> instances." message renders instead of a blank grid. The live stream keeps the filtered view current as instances start/stop.

## Implementation

- **`src/components/InstanceFilter.svelte`** (new) — controlled segmented control, cloned from the existing `ThemePicker.svelte` pattern (same `1px solid var(--ink)` pill, mono uppercase labels, invert active/hover, `:focus-visible` outline; `role="radiogroup"`).
- **`src/types.ts`** — new `InstanceFilter` union (`'all' | 'active' | 'stopped'`).
- **`src/components/TopBar.svelte`** — optional `filter` / `onFilter` props; renders the control before `<SettingsCog />`. Kept optional so `/debug` (UiShowcase) is unaffected.
- **`src/components/DashboardView.svelte`** — owns the `filter` state, derives the `visible` list, wires TopBar, iterates the filtered list, and adds the filtered-empty state.

## Verification

- `bun run checks` green (format + eslint + typecheck; 207 tests pass, 0 fail).
- New component validated clean by the official Svelte autofixer.
- Live boot not verified: no Docker daemon available in this environment (per repo guidance, fell back to the suite).