### PR TITLE
fix(ci): publish versioned + :latest Docker images; log version at startup

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,12 +1,17 @@
 name: publish-docker
 
 # Publishes a multi-arch image to the GitHub Container Registry (GHCR).
-#   - push to main   → ghcr.io/<owner>/codebay:main
-#   - v* tag (cut by release-please) → :<version>, :<major>.<minor>, and :latest
+#   - push to main                       → ghcr.io/<owner>/codebay:main
+#   - codebay-v* tag (cut by release-please) → :<version>, :<major>.<minor>, and :latest
+#
+# release-please (release-type: node) tags releases as `codebay-v0.7.0`, NOT `v0.7.0`,
+# so the trigger and the metadata patterns below both key off the `codebay-v` prefix —
+# an earlier `v*`/`type=semver` setup silently never matched, so no versioned or :latest
+# image was ever published.
 on:
   push:
     branches: [main]
-    tags: ['v*']
+    tags: ['codebay-v*']
   workflow_dispatch:
 
 concurrency:
@@ -41,19 +46,57 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository_owner }}/codebay
-          # `latest` is added automatically for the highest semver tag (flavor latest=auto).
+          # type=match strips the `codebay-` prefix that type=semver can't parse.
+          # latest=false so branch/sha builds never claim :latest; the raw line below
+          # adds :latest only on a release tag.
+          flavor: latest=false
           tags: |
             type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=match,pattern=codebay-v(\d+\.\d+\.\d+),group=1
+            type=match,pattern=codebay-v(\d+\.\d+),group=1
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/codebay-v') }}
             type=sha
+
+      # Build the amd64 image into the local daemon and smoke-test it before the
+      # multi-arch push — the Docker equivalent of npm's `bun run verify:package`.
+      # The manager serves static assets without a Docker daemon (its client resolves
+      # lazily), so no socket mount or password is needed here.
+      - name: Build amd64 image for smoke test
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          tags: codebay:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test — serves the UI and packaged sounds
+        run: |
+          docker run -d --name codebay-ci \
+            -e HOST=0.0.0.0 -e PORT=6969 -e DISABLE_OPEN_BROWSER=1 \
+            -p 6969:6969 codebay:ci
+          base=http://127.0.0.1:6969
+          for i in $(seq 1 40); do
+            curl -sf -o /dev/null "$base/" && break
+            sleep 1
+          done
+          code=$(curl -s -o /dev/null -w '%{http_code}' "$base/sounds/done.wav")
+          if [ "$code" != "200" ]; then
+            echo "::error::GET /sounds/done.wav returned $code — public/ assets are not being served"
+            docker logs codebay-ci
+            docker rm -f codebay-ci
+            exit 1
+          fi
+          echo "OK: /sounds/done.wav served ($code)"
+          docker rm -f codebay-ci
 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           # arm64 builds under QEMU emulation, so this job is slow-ish — the GHA
-          # cache below keeps subsequent runs quick.
+          # cache below (shared with the smoke-test build) keeps it quick.
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { basicAuth } from './lib/auth.server.ts';
 import { themeHandle } from './lib/theme.server.ts';
 import { PROXY_PREFIX } from './lib/proxy.server.ts';
 import {
+	APP_VERSION,
 	BASIC_AUTH_PASSWORD,
 	HOST,
 	PORT,
@@ -66,7 +67,7 @@ await Mochi.serve({
 });
 
 const url = 'http://localhost:' + PORT;
-console.log(`Server running at ${url} (bound to ${HOST})`);
+console.log(`codebay v${APP_VERSION} — server running at ${url} (bound to ${HOST})`);
 
 if (process.env.DISABLE_OPEN_BROWSER !== '1') {
 	const openCmd =


### PR DESCRIPTION
## Context

A user reported `/sounds/*.wav` 404ing on a `bunx codebay` deployment, suspecting `public/` wasn't packaged.

**The npm release is not broken.** Verified by booting `bunx codebay@latest` (0.7.0) — it serves both sounds as `200 audio/x-wav`. Every published version since `0.2.0` ships `public/sounds/*.wav`, and `bun run verify:package` already guards the npm path. The report was a **stale `bunx` cache** pinned to `codebay@0.0.1` (the one version cut before `"public"` was added to `files[]`); `bunx codebay` reuses its cache instead of re-resolving `latest`. User unblock: `bunx codebay@latest` (or clear `~/.bun/install/cache/codebay*`).

Tracing it surfaced two genuine gaps, fixed here.

## Changes

### 1. Fix the Docker release pipeline (`.github/workflows/publish-docker.yml`)
- **Real latent bug:** the workflow triggered on `tags: ['v*']`, but release-please cuts **`codebay-v*`** tags — no match. So versioned and `:latest` GHCR images were **never published on release**; Docker users were stuck on stale images (same "stale = missing assets" class, with no guard to catch it).
- Trigger → `codebay-v*`; tag extraction → `type=match` (strips the `codebay-` prefix `type=semver` can't parse); restore `:latest` on release tags via `type=raw ... enable`.
- Add a **smoke check** (parity with npm's `verify:package`): build the amd64 image with `load: true`, run it, and assert `GET /sounds/done.wav` → `200` before the multi-arch push. No daemon/auth needed — the manager serves static assets without a Docker daemon.

### 2. Print the version at startup (`src/index.ts`)
Wire the existing `APP_VERSION` into the startup log so a stale/mismatched deploy is obvious:
```
codebay v0.7.0 — server running at http://localhost:6969 (bound to 127.0.0.1)
```

## Verification
- `bun run checks` — ✅ 213 tests pass, typecheck clean.
- Booted `bun src/index.ts` → startup log shows `codebay v0.7.0 — server running at …`.
- Docker smoke step / live `docker build` verification needs a daemon (the `.devcontainer` has none); the new CI step exercises it on release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)