### PR TITLE
fix: stop zsh unmatched-glob spam while waiting for the IDE bridge lock

### DIFF
--- a/src/lib/devcontainer.server.ts
+++ b/src/lib/devcontainer.server.ts
@@ -102,9 +102,11 @@ const WAIT_FOR_INJECTIONS =
  * claude scans `~/.claude/ide/*.lock` once at startup and never retries, so it must not race
  * the code-server extension host writing that lock — hold it briefly until the bridge appears.
  * Bounded so an offline/uninstalled instance (lock never written) still yields a usable terminal.
- * No single quotes: this is spliced into the single-quoted tmux command string below.
+ * No single quotes: this is spliced into the single-quoted tmux command string below. The probe
+ * pipes ls through grep instead of globbing — tmux runs this under the user's default shell, and
+ * zsh prints "no matches found" to the terminal on every unmatched-glob iteration.
  */
-const WAIT_FOR_IDE_BRIDGE = `i=0; until ls "$HOME/.claude/ide/"*.lock >/dev/null 2>&1 || [ "$i" -ge 30 ]; do sleep 1; i=$((i + 1)); done; `;
+const WAIT_FOR_IDE_BRIDGE = `i=0; until ls "$HOME/.claude/ide/" 2>/dev/null | grep -q "\\.lock$" || [ "$i" -ge 30 ]; do sleep 1; i=$((i + 1)); done; `;
 
 /**
  * Runs under tmux so Claude survives the browser closing — code-server reaps the


### PR DESCRIPTION
## Problem

On images where the container user's default shell is zsh (e.g. the Claude reference devcontainer), the auto-launched terminal spams up to 30 lines of:

```
zsh:1: no matches found: /home/node/.claude/ide/*.lock
```

`WAIT_FOR_IDE_BRIDGE` (added in #101) polls for the IDE lock with a shell glob:

```sh
until ls "$HOME/.claude/ide/"*.lock >/dev/null 2>&1 || ...
```

tmux runs the session command under the user's default shell, and zsh — unlike bash — errors on an unmatched glob *before* `ls` runs, so the shell itself prints the error and the `ls` redirections can't suppress it. One line per iteration, once per second, until the lock appears or the 30s bound hits.

## Fix

Probe without a shell glob — the pattern is now a literal grep argument, so no shell ever expands it:

```sh
until ls "$HOME/.claude/ide/" 2>/dev/null | grep -q "\.lock$" || ...
```

Behavior is unchanged (exits as soon as a `.lock` appears, same 30s bound, still single-quote-free for the tmux splice); it's just silent on zsh.

## Verification

- Ran the snippet standalone under zsh and bash, with and without a lock file: silent in all cases, exits immediately when the lock exists, times out at the bound when it never does.
- `bun run checks` passes (format, eslint, typecheck, 213 tests) — including the existing "holds claude until the IDE bridge lockfile appears" test.