### PR TITLE
fix: show avatar name in avatar tooltip

### DIFF
--- a/src/components/Avatar.svelte
+++ b/src/components/Avatar.svelte
@@ -67,7 +67,8 @@
 	// 0.5px is a crisp single device-pixel at 2×; at 1× the cells can't spare any gutter.
 	const gap = $derived(s >= 2 ? 0.5 : 0);
 
-	const cells = $derived(decode(art ?? pickAvatar(id)));
+	const resolved = $derived(art ?? pickAvatar(id));
+	const cells = $derived(decode(resolved));
 	// The 10×10 outer ring is unlit LED cells — a bezel of real dots, not blank padding.
 	const grid = $derived(
 		Array.from({ length: 100 }, (_, i) => {
@@ -86,7 +87,7 @@
 	class:ghosting
 	role="img"
 	aria-label={name}
-	title={name}
+	title={resolved.name}
 	style="width:{10 * s}px;height:{10 *
 		s}px;--gap:{gap}px;--bx:{bx};--by:{by};--spin:{spin}deg;--hue:{hue}deg"
 	{onpointerdown}


### PR DESCRIPTION
## What

The avatar tooltip (the `title` attribute) showed the **instance** name. Now it shows the **avatar sprite's own name** (e.g. `fox`, `cat`) — the thing the picture actually depicts.

## How

`Avatar.svelte` resolves the sprite once via `art ?? pickAvatar(id)` and uses `resolved.name` for the `title`. The instance `name` is kept as the `aria-label` so screen readers still identify which instance the avatar belongs to.

## Checks

`bun run checks` passes (the lone `svelte-check` warning in `AppShell.svelte` is pre-existing and unrelated).