### PR TITLE
feat: persist the dashboard instance filter across tabs, reloads, and clients

### DIFF
--- a/src/components/AppShell.svelte
+++ b/src/components/AppShell.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ideUrl, type Instance, type Preflight } from '../types.ts';
+	import { ideUrl, type Instance, type InstanceFilter, type Preflight } from '../types.ts';
 	import { findAvatar, type AvatarArt } from '../avatars/index.ts';
 	import { SvelteSet } from 'svelte/reactivity';
 	import DashboardView from './DashboardView.svelte';
@@ -15,12 +15,14 @@
 		preflight,
 		initialPath,
 		snapshot,
-		pet
+		pet,
+		filter
 	}: {
 		preflight: Preflight;
 		initialPath: string;
 		snapshot: Instance[];
 		pet?: AvatarArt;
+		filter: InstanceFilter;
 	} = $props();
 
 	// Seeding from the SSR snapshot is intentional — the live stream overwrites it.
@@ -32,6 +34,9 @@
 	// Seeded from SSR, then updated live so changing the pet in settings swaps the header without a reload.
 	// svelte-ignore state_referenced_locally
 	let livePet = $state<AvatarArt | undefined>(pet);
+	// Owned here (not in DashboardView) so it survives the dashboard↔IDE tab switches that remount the view.
+	// svelte-ignore state_referenced_locally
+	let liveFilter = $state<InstanceFilter>(filter);
 	// svelte-ignore state_referenced_locally
 	let loaded = $state(snapshot.length > 0);
 	const running = $derived(instances.filter((i) => i.status === 'running'));
@@ -68,6 +73,14 @@
 		} catch (err) {
 			toast.error((err as Error).message);
 		}
+	}
+
+	// Optimistic local update + best-effort persist; the broadcast echo reconciles every open tab.
+	function setFilter(v: InstanceFilter) {
+		liveFilter = v;
+		void apiPost('/api/settings/filter', { value: v }).catch(() => {
+			/* best-effort — the in-memory value already reflects the choice */
+		});
 	}
 
 	// Mochi has no client router, and a document reload would tear down the code-server iframes.
@@ -174,6 +187,10 @@
 					livePet = findAvatar(msg.data.name ?? undefined);
 					return;
 				}
+				if (msg.type === 'filter') {
+					liveFilter = msg.data.value;
+					return;
+				}
 				if (msg.type === 'health') {
 					// A tick in flight when a rebuild starts probes the *old* container and
 					// reports it accessible, which would mount the iframe against the replacement too early.
@@ -250,7 +267,14 @@
 			oncancelrename={cancelRename}
 		/>
 	{:else}
-		<DashboardView preflight={livePreflight} {instances} {loaded} pet={livePet} />
+		<DashboardView
+			preflight={livePreflight}
+			{instances}
+			{loaded}
+			pet={livePet}
+			filter={liveFilter}
+			onFilter={setFilter}
+		/>
 	{/if}
 
 	<!-- Always mounted, only hidden, so the iframes survive navigation. -->

--- a/src/components/DashboardView.svelte
+++ b/src/components/DashboardView.svelte
@@ -13,13 +13,21 @@
 		preflight,
 		instances,
 		loaded,
-		pet
-	}: { preflight: Preflight; instances: Instance[]; loaded: boolean; pet?: AvatarArt } = $props();
+		pet,
+		filter,
+		onFilter
+	}: {
+		preflight: Preflight;
+		instances: Instance[];
+		loaded: boolean;
+		pet?: AvatarArt;
+		filter: InstanceFilter;
+		onFilter: (v: InstanceFilter) => void;
+	} = $props();
 
 	type Action = 'start' | 'stop' | 'delete' | 'rebuild';
 
 	let browserOpen = $state(false);
-	let filter = $state<InstanceFilter>('all');
 	let creating = $state(false);
 	let actionError = $state<string | null>(null);
 	let editingId = $state<string | null>(null);
@@ -136,7 +144,7 @@
 	{ready}
 	{creating}
 	{filter}
-	onFilter={(v) => (filter = v)}
+	{onFilter}
 	onNew={() => (browserOpen = true)}
 	onDeleteAll={deleteAll}
 />

--- a/src/lib/db.isolated.test.ts
+++ b/src/lib/db.isolated.test.ts
@@ -80,6 +80,14 @@ describe('options key/value helpers', () => {
 		db.setOption('default_image', 'other/image:2');
 		expect(db.getOption('default_image')).toBe('other/image:2');
 	});
+
+	test('instance_filter round-trips through the option store', () => {
+		expect(db.getOption('instance_filter')).toBeNull();
+		db.setOption('instance_filter', 'active');
+		expect(db.getOption('instance_filter')).toBe('active');
+		db.setOption('instance_filter', 'stopped');
+		expect(db.getOption('instance_filter')).toBe('stopped');
+	});
 });
 
 describe('updateInstance image_source + insert round-trip', () => {

--- a/src/lib/instances.server.ts
+++ b/src/lib/instances.server.ts
@@ -51,7 +51,12 @@ import { isRepoUrl, parseRepoUrl } from './repo-url.ts';
 import { currentHealthSnapshots, stopHealthMonitor, syncHealthMonitors } from './health.server.ts';
 import { pickFreePort } from './ports.server.ts';
 import type { ServerWebSocket } from 'bun';
-import type { Instance, InstanceHealth } from '../types.ts';
+import {
+	isInstanceFilter,
+	type Instance,
+	type InstanceFilter,
+	type InstanceHealth
+} from '../types.ts';
 
 /**
  * `bridge_token` authenticates the no-Basic-Auth `/api/bridge/` endpoint, so it
@@ -108,7 +113,9 @@ export type StreamEvent =
 	| { type: 'health'; data: { id: string; health: InstanceHealth } }
 	| { type: 'preflight'; data: { docker: boolean; cli: boolean } }
 	// `name` is the chosen sprite, or null for the default box logo. Lets the header swap live.
-	| { type: 'pet'; data: { name: string | null } };
+	| { type: 'pet'; data: { name: string | null } }
+	// The dashboard run-state filter, so a change in one tab propagates to every open client.
+	| { type: 'filter'; data: { value: InstanceFilter } };
 
 interface StreamHub {
 	sockets: Set<ServerWebSocket<unknown>>;
@@ -159,6 +166,11 @@ export function broadcastPet(name: string | null): void {
 	broadcast({ type: 'pet', data: { name } });
 }
 
+/** Called when the filter changes so every open dashboard reflects it without a reload. */
+export function broadcastFilter(value: InstanceFilter): void {
+	broadcast({ type: 'filter', data: { value } });
+}
+
 async function reconcileInstances(force = false): Promise<void> {
 	const list = await listInstances();
 	const listJson = JSON.stringify(list);
@@ -200,6 +212,12 @@ export function streamOpen(ws: ServerWebSocket<unknown>): void {
 	void backgroundPreflight().then((pf) => sendTo(ws, { type: 'preflight', data: pf }));
 	// Keeps a reconnecting client correct even if the pet changed while it was away.
 	sendTo(ws, { type: 'pet', data: { name: getOption('pet') || null } });
+	// Same, for the filter, so a client that reconnects picks up a change made while it was away.
+	const savedFilter = getOption('instance_filter');
+	sendTo(ws, {
+		type: 'filter',
+		data: { value: isInstanceFilter(savedFilter) ? savedFilter : 'all' }
+	});
 }
 
 export function streamClose(ws: ServerWebSocket<unknown>): void {

--- a/src/pages/App.svelte
+++ b/src/pages/App.svelte
@@ -2,20 +2,22 @@
 	import '@fontsource-variable/doto';
 	import '@fontsource-variable/jetbrains-mono';
 	import AppShell from '../components/AppShell.svelte';
-	import type { Instance, Preflight } from '../types.ts';
+	import type { Instance, InstanceFilter, Preflight } from '../types.ts';
 	import type { AvatarArt } from '../avatars/index.ts';
 
 	let {
 		preflight,
 		initialPath,
 		snapshot,
-		pet
+		pet,
+		filter
 	}: {
 		preflight: Preflight;
 		initialPath: string;
 		snapshot: Instance[];
 		pet?: AvatarArt;
+		filter: InstanceFilter;
 	} = $props();
 </script>
 
-<AppShell {preflight} {initialPath} {snapshot} {pet} mochi:hydrate />
+<AppShell {preflight} {initialPath} {snapshot} {pet} {filter} mochi:hydrate />

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -25,6 +25,7 @@ import { pickNamePrompt } from './avatars/name-prompts.ts';
 import { avatars, findAvatar } from './avatars/index.ts';
 import {
 	addForwardedPort,
+	broadcastFilter,
 	broadcastPet,
 	createInstance,
 	deleteAllInstances,
@@ -54,6 +55,7 @@ import { wsUpgradeAllowed } from './lib/auth.server.ts';
 import { clearAttention, setAttention } from './lib/bridge.server.ts';
 import { timingSafeEqualStr } from './lib/crypto.server.ts';
 import { proxyRoutes } from './lib/proxy.server.ts';
+import { isInstanceFilter, type InstanceFilter } from './types.ts';
 
 async function preflight() {
 	const [docker, cli, auth] = await Promise.all([
@@ -81,6 +83,12 @@ async function preflight() {
 /** The header pet logo, resolved from the DB option. A name that left the catalog reads as "off". */
 function currentPet() {
 	return findAvatar(getOption('pet') ?? undefined);
+}
+
+/** The dashboard run-state filter, resolved from the DB option; an unset/invalid value reads as "all". */
+function currentFilter(): InstanceFilter {
+	const v = getOption('instance_filter');
+	return isInstanceFilter(v) ? v : 'all';
 }
 
 /** Lets a route handler just `throw` for both validation and business-logic failures. */
@@ -120,7 +128,8 @@ export const routes: Record<string, MochiRouteValue> = {
 			preflight: await preflight(),
 			initialPath: '/',
 			snapshot: await listInstances(),
-			pet: currentPet()
+			pet: currentPet(),
+			filter: currentFilter()
 		})
 	}),
 
@@ -131,7 +140,8 @@ export const routes: Record<string, MochiRouteValue> = {
 				preflight: await preflight(),
 				initialPath: `/ide/${params.id}`,
 				snapshot: await listInstances(),
-				pet: currentPet()
+				pet: currentPet(),
+				filter: currentFilter()
 			};
 		}
 	}),
@@ -380,6 +390,16 @@ export const routes: Record<string, MochiRouteValue> = {
 		} catch (err) {
 			return apiError(400, (err as Error).message);
 		}
+	}),
+
+	// Persists the dashboard filter and pushes it to every open tab over the central stream.
+	'/api/settings/filter': Mochi.api(async ({ method, request }) => {
+		if (method !== 'POST') return apiError(405, 'Method Not Allowed');
+		const body = (await request.json().catch(() => null)) as { value?: string } | null;
+		if (!body || !isInstanceFilter(body.value)) return apiError(400, 'Invalid filter');
+		setOption('instance_filter', body.value);
+		broadcastFilter(body.value);
+		return json({ value: body.value });
 	}),
 
 	'/api/stream': Mochi.ws({

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test';
+import { isInstanceFilter } from './types.ts';
+
+describe('isInstanceFilter', () => {
+	test('accepts the three valid tokens', () => {
+		expect(isInstanceFilter('all')).toBe(true);
+		expect(isInstanceFilter('active')).toBe(true);
+		expect(isInstanceFilter('stopped')).toBe(true);
+	});
+
+	test('rejects anything else', () => {
+		for (const v of ['', 'ALL', 'running', 'none', null, undefined, 0, {}]) {
+			expect(isInstanceFilter(v)).toBe(false);
+		}
+	});
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,10 @@ export interface Instance {
 /** Dashboard run-state view filter: All | Active (running/creating) | Stopped (stopped/error). */
 export type InstanceFilter = 'all' | 'active' | 'stopped';
 
+export function isInstanceFilter(v: unknown): v is InstanceFilter {
+	return v === 'all' || v === 'active' || v === 'stopped';
+}
+
 /** Live only — never persisted, so it always reflects the most recent probe. */
 export interface InstanceHealth {
 	containerRunning: boolean;


### PR DESCRIPTION
## What & why

The top-bar **All / Active / Stopped** filter lived as local `$state` inside `DashboardView.svelte`. Because the persistent `AppShell` renders the dashboard only in its `{:else}` branch, navigating to an IDE tab (`/ide/:id`) **destroys** `DashboardView` and coming back **recreates** it — so the filter always snapped back to `all`, and it never survived a page reload.

This makes the filter remembered across dashboard ↔ IDE tab switches, across reloads, and propagated live to every open tab — mirroring the existing header-avatar ("pet") mechanism (no localStorage; the DB is the source of truth, pushed over the existing central WebSocket).

## How

- **State ownership moves up** from `DashboardView` into the persistent `AppShell` (`liveFilter`), which is what makes it survive the tab switches that remount the dashboard. `DashboardView` becomes presentational (`filter` + `onFilter` props).
- **Seed from the DB** via `serverProps` on `/` and `/ide/:id` (new `instance_filter` option; unset/invalid → `all`), so the first paint is correct with no flash.
- **Persist + broadcast** through a new `POST /api/settings/filter` route: validates, `setOption('instance_filter', …)`, then `broadcastFilter(…)` over `/api/stream` — so a change in one tab updates every other open client, exactly like changing the pet in settings. `streamOpen` also seeds the filter so a reconnecting client stays correct.
- No DB migration needed — the `options` table already exists; the key is created on first write.

## Files
- `src/types.ts` — `isInstanceFilter` guard
- `src/lib/instances.server.ts` — `{type:'filter'}` stream event, `broadcastFilter`, `streamOpen` seed
- `src/routes.ts` — `serverProps` seed + `POST /api/settings/filter`
- `src/pages/App.svelte`, `src/components/AppShell.svelte` — thread + own the state
- `src/components/DashboardView.svelte` — filter becomes a prop

## Testing
- `bun run checks` — passes (216 tests, typecheck clean; the one `snapshot` svelte-check warning is pre-existing on `main`).
- New tests: `src/types.test.ts` (guard) and an `instance_filter` round-trip in `src/lib/db.isolated.test.ts`.
- Live smoke test against `bun run dev`:
  - Default SSR → **All** active; `POST {value:"active"}` → `{"value":"active"}`; invalid value → **400**; reload → **Active** active (seeded from DB).