### PR TITLE
feat: label instance cards with Claude's current task

### DIFF
--- a/src/components/InstanceCard.svelte
+++ b/src/components/InstanceCard.svelte
@@ -82,6 +82,9 @@
 		{/if}
 		<StatusBadge status={instance.status} />
 	</div>
+	{#if instance.task}
+		<p class="task" title={instance.task}>{instance.task}</p>
+	{/if}
 	<div class="path" title={instance.source_path}>{instance.source_path}</div>
 	{#if instance.status === 'running'}
 		<PortsBox ports={instance.forwarded_ports} />
@@ -243,6 +246,23 @@
 		background: var(--bg);
 		color: var(--ink);
 		outline: none;
+	}
+	.task {
+		margin: 8px 0 0;
+		font-size: 13px;
+		font-style: italic;
+		color: var(--ink);
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+	.task::before {
+		content: open-quote;
+	}
+	.task::after {
+		content: close-quote;
 	}
 	.path {
 		margin-top: 10px;

--- a/src/container-injections/attention-hooks.ts
+++ b/src/container-injections/attention-hooks.ts
@@ -21,12 +21,15 @@ const HOOK_LOG = '${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.bridge-hook.log';
  * `-f` is deliberately absent so a 4xx still yields an HTTP status to log rather than
  * curl bailing early; `curl_exit` then separates "unreachable" from "answered with a status".
  */
-function hookFor(id: string, state: 'done' | 'waiting' | 'busy') {
+function hookFor(id: string, state: 'done' | 'waiting' | 'busy', forwardStdin = false) {
 	const url = `${bridgeUrl()}?id=${encodeURIComponent(id)}&state=${state}`;
+	// UserPromptSubmit pipes its stdin (the hook JSON) through so the bridge can read the
+	// prompt; other hooks send no body. `@-` reads stdin, which Claude always supplies here.
+	const body = forwardStdin ? '--data-binary @- ' : '';
 	const command =
 		`log="${HOOK_LOG}"; ` +
 		// The Content-Type is for Mochi's CSRF guard, which reads a bodiless POST as a form submit.
-		`http=$(curl -sS -m 5 -o /dev/null -w '%{http_code}' -X POST -H 'Content-Type: application/json' -H @"${HEADER_FILE}" '${url}' 2>>"$log"); ` +
+		`http=$(curl -sS -m 5 -o /dev/null -w '%{http_code}' -X POST ${body}-H 'Content-Type: application/json' -H @"${HEADER_FILE}" '${url}' 2>>"$log"); ` +
 		`rc=$?; ` +
 		`printf '[%s] state=${state} http=%s curl_exit=%s\\n' "$(date -Is 2>/dev/null || date)" "$http" "$rc" >> "$log" 2>/dev/null; ` +
 		// Keep the log bounded without a race window that could lose the file.
@@ -50,7 +53,7 @@ export function attentionHookSettings(id: string): Record<string, unknown> {
 		hooks: {
 			Stop: hookFor(id, 'done'),
 			Notification: hookFor(id, 'waiting'),
-			UserPromptSubmit: hookFor(id, 'busy')
+			UserPromptSubmit: hookFor(id, 'busy', true)
 		}
 	};
 }

--- a/src/container-injections/injections.isolated.test.ts
+++ b/src/container-injections/injections.isolated.test.ts
@@ -275,6 +275,17 @@ describe('attentionHookSettings', () => {
 		// mode-600 header file at runtime, keeping it off curl's argv (and out of ps).
 		expect(json).toContain('.bridge-header');
 	});
+
+	test('only UserPromptSubmit forwards its stdin, so the prompt reaches the bridge', () => {
+		const hooks = attentionHookSettings('inst-123').hooks as Record<
+			string,
+			{ hooks: { command: string }[] }[]
+		>;
+		const cmd = (event: string) => hooks[event]![0]!.hooks[0]!.command;
+		expect(cmd('UserPromptSubmit')).toContain('--data-binary @-');
+		expect(cmd('Stop')).not.toContain('--data-binary');
+		expect(cmd('Notification')).not.toContain('--data-binary');
+	});
 });
 
 describe('hasAttentionHook', () => {

--- a/src/lib/bridge.isolated.test.ts
+++ b/src/lib/bridge.isolated.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+import { clearTask, getTask, setTask } from './bridge.server.ts';
+
+describe('task store', () => {
+	test('round-trips the latest prompt as an instance task', () => {
+		setTask('inst-task-1', 'Add rate limiting to the API');
+		expect(getTask('inst-task-1')).toBe('Add rate limiting to the API');
+	});
+
+	test('collapses whitespace so a multi-line prompt renders as one line', () => {
+		setTask('inst-task-2', '  Fix the\n  flaky   auth\ttest  ');
+		expect(getTask('inst-task-2')).toBe('Fix the flaky auth test');
+	});
+
+	test('caps an overlong prompt so the in-memory map stays bounded', () => {
+		setTask('inst-task-3', 'x'.repeat(1000));
+		expect(getTask('inst-task-3')!.length).toBe(500);
+	});
+
+	test('an empty or whitespace-only prompt leaves the task untouched', () => {
+		setTask('inst-task-4', 'real task');
+		setTask('inst-task-4', '   ');
+		expect(getTask('inst-task-4')).toBe('real task');
+	});
+
+	test('clearTask drops it; an unknown id reads as null', () => {
+		setTask('inst-task-5', 'something');
+		clearTask('inst-task-5');
+		expect(getTask('inst-task-5')).toBeNull();
+		expect(getTask('never-set')).toBeNull();
+	});
+});

--- a/src/lib/bridge.server.ts
+++ b/src/lib/bridge.server.ts
@@ -6,9 +6,33 @@ export type AttentionState = 'done' | 'waiting';
 // Pin to globalThis so dev-mode hot reload doesn't drop pending signals.
 const globalForAttention = globalThis as unknown as {
 	__codebayAttention?: Map<string, AttentionState>;
+	__codebayTask?: Map<string, string>;
 };
 const attention: Map<string, AttentionState> = (globalForAttention.__codebayAttention ??=
 	new Map());
+
+// The most recent prompt Claude was handed inside each container — a UI-only "current task"
+// label, never persisted, keyed by instance id like attention above.
+const tasks: Map<string, string> = (globalForAttention.__codebayTask ??= new Map());
+
+/** Cap on the stored task so one runaway prompt can't bloat the in-memory map. */
+const MAX_TASK_LEN = 500;
+
+export function getTask(id: string): string | null {
+	return tasks.get(id) ?? null;
+}
+
+export function setTask(id: string, task: string): void {
+	// Collapse whitespace so a multi-line prompt renders as one tidy card subtitle.
+	const cleaned = task.replace(/\s+/g, ' ').trim().slice(0, MAX_TASK_LEN);
+	if (!cleaned || tasks.get(id) === cleaned) return;
+	tasks.set(id, cleaned);
+	triggerReconcile();
+}
+
+export function clearTask(id: string): void {
+	if (tasks.delete(id)) triggerReconcile();
+}
 
 export function getAttention(id: string): AttentionState | null {
 	return attention.get(id) ?? null;

--- a/src/lib/instances.server.ts
+++ b/src/lib/instances.server.ts
@@ -43,7 +43,7 @@ import {
 	writeOverrideConfig
 } from './devcontainer.server.ts';
 import { writeContainerFile } from './container-files.server.ts';
-import { clearAttention, getAttention } from './bridge.server.ts';
+import { clearAttention, getAttention, getTask } from './bridge.server.ts';
 import { proxyPathFor } from './proxy.server.ts';
 import { resolveInjections } from './injections.server.ts';
 import { cloneRepo, readGitBranch } from './git.server.ts';
@@ -469,6 +469,7 @@ export async function listInstances(): Promise<Instance[]> {
 		...sanitizeInstance(row),
 		git_branch: branches.get(row.id) ?? null,
 		attention: getAttention(row.id),
+		task: getTask(row.id),
 		forwarded_ports: forwards.get(row.id) ?? []
 	}));
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -52,7 +52,7 @@ import {
 } from './lib/db.server.ts';
 import { APP_VERSION, DEFAULT_COPY_IGNORE, DEFAULT_IMAGE } from './lib/config.server.ts';
 import { wsUpgradeAllowed } from './lib/auth.server.ts';
-import { clearAttention, setAttention } from './lib/bridge.server.ts';
+import { clearAttention, setAttention, setTask } from './lib/bridge.server.ts';
 import { timingSafeEqualStr } from './lib/crypto.server.ts';
 import { proxyRoutes } from './lib/proxy.server.ts';
 import { isInstanceFilter, type InstanceFilter } from './types.ts';
@@ -78,6 +78,21 @@ async function preflight() {
 		)
 	]);
 	return { docker, cli, auth };
+}
+
+/**
+ * Pull the `prompt` out of a Claude UserPromptSubmit hook body forwarded to the bridge.
+ * Bounded read + defensive parse: a missing, oversized, or non-JSON body just yields null.
+ */
+async function readHookPrompt(request: Request): Promise<string | null> {
+	try {
+		const body = (await request.text()).slice(0, 100_000);
+		if (!body) return null;
+		const parsed = JSON.parse(body) as { prompt?: unknown };
+		return typeof parsed.prompt === 'string' && parsed.prompt.trim() ? parsed.prompt : null;
+	} catch {
+		return null;
+	}
 }
 
 /** The header pet logo, resolved from the DB option. A name that left the catalog reads as "off". */
@@ -513,6 +528,10 @@ export const routes: Record<string, MochiRouteValue> = {
 		if (state === 'done') setAttention(id, 'done');
 		else if (state === 'waiting') setAttention(id, 'waiting');
 		else clearAttention(id); // 'busy' / anything else → Claude resumed, dismiss the pulse
+		// The UserPromptSubmit hook forwards its stdin JSON here; parse it host-side so the
+		// container needs no jq/node, and surface the prompt as the card's "current task".
+		const prompt = await readHookPrompt(request);
+		if (prompt) setTask(id, prompt);
 		console.log(
 			`[bridge] accepted id=${id} → attention=${state === 'done' || state === 'waiting' ? state : 'cleared'}`
 		);

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,8 @@ export interface Instance {
 	/** Polled per reconcile rather than persisted; null if unknown. */
 	git_branch: string | null;
 	attention: 'done' | 'waiting' | null;
+	/** Most recent prompt handed to Claude in the container; null until one arrives. Live-only. */
+	task: string | null;
 	forwarded_ports: PortForward[];
 }
 


### PR DESCRIPTION
## What

Each instance card on the dashboard now shows **the most recent prompt Claude was handed inside its container**, rendered as a quoted subtitle under the instance name. The dashboard reads as "what is each session working on" at a glance.

If Claude hasn't been given a prompt yet, the card looks exactly as it does today (just the repo/folder name) — the label is purely additive.

## How

The `UserPromptSubmit` attention hook already `POST`s to the bridge on every prompt (to clear the pulse). It now also **forwards its stdin** — the Claude hook JSON — via `curl --data-binary @-`:

- The bridge route parses the `prompt` field **host-side** (`readHookPrompt`), so the container needs no `jq`/`node`/`python`.
- The prompt is stored as a **live, UI-only `task`** on the instance in `bridge.server.ts`, mirroring the existing `attention` signal (in-memory, pinned to `globalThis`, never persisted). Whitespace is collapsed to one line and the value is capped at 500 chars.
- `listInstances` folds `task` into the instance DTO next to `git_branch`/`attention`; the card renders it with a 2-line clamp.

## Signal flow

`UserPromptSubmit` hook → `curl --data-binary @-` → `/api/bridge/attention` (token-authed) → parse `prompt` → `setTask(id, …)` → central stream → `InstanceCard`.

## Tests

- `bridge.isolated.test.ts` — task store round-trip, whitespace collapse, 500-char cap, empty-prompt no-op, `clearTask`.
- `injections.isolated.test.ts` — only `UserPromptSubmit` carries `--data-binary @-`; `Stop`/`Notification` don't.
- Full `bun run checks` passes (223 tests, 0 fail).

## Not covered / follow-ups

- The task label is shown on the dashboard card only, not the IDE tab strip or details header (matching where the git branch is shown today).
- End-to-end verification (a real container firing the hook) wasn't run — no live Docker daemon in this environment; the orchestration is covered by the isolated tests against stubs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)