### PR TITLE
test: cover the Basic Auth gate and origin guard on the instance proxy

### DIFF
--- a/src/lib/auth.isolated.test.ts
+++ b/src/lib/auth.isolated.test.ts
@@ -1,0 +1,219 @@
+import { afterAll, beforeAll, describe, expect, mock, test } from 'bun:test';
+import type { MochiEvent, MochiResolveFn } from 'mochi-framework';
+import * as config from './config.server.ts';
+import { basicAuth, wsUpgradeAllowed } from './auth.server.ts';
+import { PROXY_PREFIX, proxyRoutes } from './proxy.server.ts';
+
+const HOST = 'codebay.test';
+const ORIGIN = `http://${HOST}`;
+const PASSWORD = 'hunter2';
+
+/**
+ * `BASIC_AUTH_PASSWORD` is a module const, so each block pins the value it needs rather than
+ * inheriting whatever the developer happens to have exported. Snapshotted before any mocking
+ * so the override never compounds; `auth.server.ts` reads it through a live binding, which is
+ * why re-mocking works on the already-imported module above.
+ */
+const realConfig = { ...config };
+function setPassword(password: string): void {
+	mock.module('./config.server.ts', () => ({ ...realConfig, BASIC_AUTH_PASSWORD: password }));
+}
+
+interface ReqOpts {
+	method?: string;
+	/** Omitted means no `Origin` header at all — i.e. a non-browser client. */
+	origin?: string;
+	/** Omitted means no `Authorization` header. */
+	password?: string;
+	username?: string;
+	upgrade?: boolean;
+	csrf?: boolean;
+}
+
+function request(path: string, o: ReqOpts = {}): Request {
+	const headers = new Headers({ host: HOST });
+	if (o.origin !== undefined) headers.set('origin', o.origin);
+	if (o.password !== undefined) {
+		headers.set('authorization', `Basic ${btoa(`${o.username ?? 'admin'}:${o.password}`)}`);
+	}
+	if (o.upgrade) {
+		headers.set('upgrade', 'websocket');
+		headers.set('connection', 'Upgrade');
+	}
+	if (o.csrf) headers.set('x-codebay-request', '1');
+	return new Request(`http://${HOST}${path}`, { method: o.method ?? 'GET', headers });
+}
+
+/** `resolved` is the assertion that matters: a rejected request must never reach the route. */
+async function run(req: Request): Promise<{ status: number; resolved: boolean; res: Response }> {
+	let resolved = false;
+	const resolve: MochiResolveFn = async () => {
+		resolved = true;
+		return new Response('reached the route');
+	};
+	const event = {
+		request: req,
+		url: new URL(req.url),
+		locals: {},
+		kind: 'api',
+		isWarmup: false,
+		server: undefined as never
+	} as MochiEvent;
+	const res = await basicAuth({ event, resolve });
+	return { status: res.status, resolved, res };
+}
+
+// Terminal-mode instances reach ttyd over `/p/:id/ws`, the same proxy route the IDE uses for
+// code-server. Neither has auth of its own, so this gate is the only thing in front of a
+// writable shell — hence the "never reached the route" assertion on every rejection.
+const TERMINAL_WS = `${PROXY_PREFIX}/term1/ws`;
+const PROXY_HTTP = `${PROXY_PREFIX}/term1/`;
+
+afterAll(() => setPassword(realConfig.BASIC_AUTH_PASSWORD));
+
+describe('auth gate with no password (the local-dev default)', () => {
+	beforeAll(() => setPassword(''));
+
+	test('accepts a same-origin WebSocket upgrade', () => {
+		expect(wsUpgradeAllowed(request(TERMINAL_WS, { origin: ORIGIN, upgrade: true }))).toBe(true);
+	});
+
+	test('rejects cross-site WebSocket hijacking even with no password set', () => {
+		expect(
+			wsUpgradeAllowed(request(TERMINAL_WS, { origin: 'https://evil.com', upgrade: true }))
+		).toBe(false);
+	});
+
+	test('rejects an opaque `Origin: null` (sandboxed iframe)', () => {
+		expect(wsUpgradeAllowed(request(TERMINAL_WS, { origin: 'null', upgrade: true }))).toBe(false);
+	});
+
+	test('rejects an origin that merely has the host as a prefix', () => {
+		expect(
+			wsUpgradeAllowed(request(TERMINAL_WS, { origin: `http://${HOST}.evil.com`, upgrade: true }))
+		).toBe(false);
+	});
+
+	test('rejects the same host on a different port', () => {
+		expect(
+			wsUpgradeAllowed(request(TERMINAL_WS, { origin: `http://${HOST}:1234`, upgrade: true }))
+		).toBe(false);
+	});
+
+	test('allows a missing Origin, which is how non-browser clients present', () => {
+		expect(wsUpgradeAllowed(request(TERMINAL_WS, { upgrade: true }))).toBe(true);
+	});
+
+	test('handle rejects a cross-origin upgrade before it reaches the proxy', async () => {
+		const { status, resolved } = await run(
+			request(TERMINAL_WS, { origin: 'https://evil.com', upgrade: true })
+		);
+		expect(status).toBe(403);
+		expect(resolved).toBe(false);
+	});
+
+	test('handle passes a same-origin upgrade through', async () => {
+		const { resolved } = await run(request(TERMINAL_WS, { origin: ORIGIN, upgrade: true }));
+		expect(resolved).toBe(true);
+	});
+
+	test('mutating /api/ call without the CSRF header is refused', async () => {
+		const { status, resolved } = await run(
+			request('/api/instances/term1/split', { method: 'POST', origin: ORIGIN })
+		);
+		expect(status).toBe(403);
+		expect(resolved).toBe(false);
+	});
+
+	test('mutating /api/ call with the CSRF header is allowed', async () => {
+		const { resolved } = await run(
+			request('/api/instances/term1/split', { method: 'POST', origin: ORIGIN, csrf: true })
+		);
+		expect(resolved).toBe(true);
+	});
+
+	test('the container bridge is exempt from the CSRF header', async () => {
+		const { resolved } = await run(request('/api/bridge/attention', { method: 'POST' }));
+		expect(resolved).toBe(true);
+	});
+});
+
+describe('auth gate with a password set', () => {
+	beforeAll(() => setPassword(PASSWORD));
+
+	test('proxied HTTP without credentials is challenged', async () => {
+		const { status, resolved, res } = await run(request(PROXY_HTTP, { origin: ORIGIN }));
+		expect(status).toBe(401);
+		expect(res.headers.get('WWW-Authenticate')).toContain('Basic');
+		expect(resolved).toBe(false);
+	});
+
+	test('a wrong password is refused', async () => {
+		const { status, resolved } = await run(
+			request(PROXY_HTTP, { origin: ORIGIN, password: 'wrong' })
+		);
+		expect(status).toBe(401);
+		expect(resolved).toBe(false);
+	});
+
+	test('a wrong username is refused even with the right password', async () => {
+		const { status, resolved } = await run(
+			request(PROXY_HTTP, { origin: ORIGIN, username: 'root', password: PASSWORD })
+		);
+		expect(status).toBe(401);
+		expect(resolved).toBe(false);
+	});
+
+	test('correct credentials pass through', async () => {
+		const { resolved } = await run(request(PROXY_HTTP, { origin: ORIGIN, password: PASSWORD }));
+		expect(resolved).toBe(true);
+	});
+
+	test('the terminal WebSocket without credentials never reaches the proxy', async () => {
+		const { status, resolved } = await run(request(TERMINAL_WS, { origin: ORIGIN, upgrade: true }));
+		expect(status).toBe(401);
+		expect(resolved).toBe(false);
+	});
+
+	test('the terminal WebSocket with credentials but a foreign origin is refused', async () => {
+		const { status, resolved } = await run(
+			request(TERMINAL_WS, { origin: 'https://evil.com', upgrade: true, password: PASSWORD })
+		);
+		expect(status).toBe(403);
+		expect(resolved).toBe(false);
+	});
+
+	test('the terminal WebSocket with correct same-origin credentials is allowed', async () => {
+		const { resolved } = await run(
+			request(TERMINAL_WS, { origin: ORIGIN, upgrade: true, password: PASSWORD })
+		);
+		expect(resolved).toBe(true);
+	});
+
+	test('wsUpgradeAllowed requires credentials once a password is set', () => {
+		expect(wsUpgradeAllowed(request('/api/stream', { origin: ORIGIN, upgrade: true }))).toBe(false);
+		expect(
+			wsUpgradeAllowed(request('/api/stream', { origin: ORIGIN, upgrade: true, password: 'wrong' }))
+		).toBe(false);
+		expect(
+			wsUpgradeAllowed(
+				request('/api/stream', { origin: ORIGIN, upgrade: true, password: PASSWORD })
+			)
+		).toBe(true);
+	});
+
+	test('the container bridge stays reachable without the app password', async () => {
+		const { resolved } = await run(request('/api/bridge/attention', { method: 'POST' }));
+		expect(resolved).toBe(true);
+	});
+});
+
+describe('proxy route wiring', () => {
+	// `Mochi.ws` routes are dispatched by Bun directly and never reach the handle chain. Moving
+	// the proxy onto one would silently unauthenticate every instance, terminal and IDE alike.
+	test('the proxy wildcard is a handle-wrapped route, not a Mochi.ws route', () => {
+		const route = proxyRoutes[`${PROXY_PREFIX}/:id/*`];
+		expect(route).toBeDefined();
+		expect(route).not.toHaveProperty('__mochiWs');
+	});
+});

--- a/src/lib/instances.server.ts
+++ b/src/lib/instances.server.ts
@@ -524,6 +524,10 @@ export async function addForwardedPort(id: string, containerPort: number): Promi
 	if (!Number.isInteger(containerPort) || containerPort < 1 || containerPort > 65535) {
 		throw new Error('Port must be an integer between 1 and 65535');
 	}
+	// Forwards publish on PUBLISH_HOST (0.0.0.0 under HOST=0.0.0.0), so forwarding the port the
+	// instance is actually served on would republish code-server/ttyd — neither of which has auth
+	// of its own — outside the Basic-Auth-gated proxy. Scoped to the live surface on purpose: in
+	// terminal mode nothing listens on 8080, and it's far too common an app port to reserve.
 	const reserved = row.mode === 'terminal' ? TTYD_PORT : CODE_SERVER_PORT;
 	if (containerPort === reserved) {
 		throw new Error(

--- a/src/lib/proxy.server.ts
+++ b/src/lib/proxy.server.ts
@@ -76,7 +76,8 @@ async function proxyHttp(event: MochiApiEvent, port: number, rest: string): Prom
 	headers.set('host', `127.0.0.1:${port}`);
 	headers.delete('accept-encoding'); // ask for an unencoded body so we can stream it verbatim
 	// code-server runs with `--auth none`, so forwarding this would only leak the app password.
-	// `cookie` is deliberately kept: the manager sets none, so every cookie here is code-server's.
+	// `cookie` is deliberately kept: the manager's only same-origin cookie is the UI theme, so
+	// anything else here belongs to the upstream and has to survive the round trip.
 	headers.delete('authorization');
 	const hasBody = event.method !== 'GET' && event.method !== 'HEAD';
 	let upstream: Response;


### PR DESCRIPTION
## Why

Following a security validation of the new terminal-only mode (#119). The mode itself is **correctly gated** — no findings — but the review surfaced that `basicAuth` and `wsUpgradeAllowed` had **no test coverage at all**. `src/index.isolated.test.ts` touches the proxy path only to check the *theme* handle.

That matters because `/p/:id/*` is the only thing standing in front of code-server and ttyd, neither of which authenticates on its own. Terminal mode sharpened the gap: #119 restructured the upgrade path to negotiate ttyd's `tty` subprotocol, so the handshake now dials upstream *during* the handle chain rather than after it. That ordering is load-bearing and was untested.

## What

`src/lib/auth.isolated.test.ts` — 21 tests over both functions, in both the password and no-password configurations. Every rejection asserts the request **never reached the route**, not merely that the status was 4xx, so an upgrade can't be refused only after the container has already been contacted.

Covered: missing credentials, wrong password, wrong username, cross-origin, `Origin: null` (sandboxed iframe), host-prefix (`host.evil.com`) and port-mismatch origins, the `/api/` CSRF header requirement, and the container bridge's exemption from both gates.

Plus one structural test: the proxy wildcard must not be a `Mochi.ws` route. Those are dispatched by Bun directly and never reach the handle chain (see CLAUDE.md), so moving it there would silently unauthenticate every instance, terminal and IDE alike.

`BASIC_AUTH_PASSWORD` is a module const, so each block pins its own value via `mock.module` rather than inheriting whatever the developer has exported — the tests are hermetic either way.

## Comment corrections (no behavior change)

- `proxy.server.ts` claimed the manager sets no cookies, so every forwarded cookie belonged to the upstream. It does set one — the UI theme (`src/theme.ts`), at `path: /`, which is forwarded into containers. Harmless content, but the stated premise was wrong.
- `addForwardedPort`'s reserved-port check had no rationale. It's what stops a forward from republishing the served port *outside* the auth gate, on `0.0.0.0` under `HOST=0.0.0.0`. Noted why it's deliberately scoped to the live surface: in terminal mode nothing listens on 8080, and it's far too common an app port to reserve.

## Testing

`bun run checks` — **256 pass, 0 fail**, typecheck/eslint/format clean.

Mutation-tested, since passing tests prove nothing unless they fail when the protection is removed:

| Mutation | Tests failed |
|---|---|
| origin guard always returns true | 6 |
| `/p/` paths skip the password check | 4 |
| CSRF header no longer required | 1 |

The behavior these lock in was also verified live before writing them — a real server with a password, a stand-in ttyd upstream, and a dial counter confirming **0** upstream connections across seven rejected handshake shapes and exactly **1** for the authorized one.

Tests only — no runtime code changed, so nothing here needs a live Docker daemon.