### PR TITLE
fix: stop terminal mode installing Node via nvm into project images

### DIFF
--- a/src/container-injections/claude-code-install.ts
+++ b/src/container-injections/claude-code-install.ts
@@ -1,0 +1,67 @@
+import { checkPresence, execInContainer } from '../lib/exec.server.ts';
+import type { Injection } from '../lib/injections.server.ts';
+
+/**
+ * Sniffs before installing, because a project-supplied image usually ships its own Claude Code —
+ * and because the alternative (the upstream node feature) installs via nvm, which hard-fails on
+ * any image that sets NPM_CONFIG_PREFIX. Neither branch here touches nvm: npm when the image has
+ * Node, else the standalone installer, which needs no Node at all.
+ *
+ * `$1` is the remote user (the injection passes it; the build-time feature falls back to the
+ * devcontainer CLI's `$_REMOTE_USER`) — the standalone installer puts the binary under that
+ * user's `$HOME`, so running it as root would strand it in `/root`.
+ */
+export const INSTALL_SCRIPT =
+	'if command -v claude >/dev/null 2>&1; then exit 0; fi\n' +
+	'if command -v npm >/dev/null 2>&1 && npm install -g @anthropic-ai/claude-code@latest >/dev/null 2>&1; then\n' +
+	'  p="$(npm prefix -g 2>/dev/null)"\n' +
+	// npm's global bin is off PATH whenever the image sets its own NPM_CONFIG_PREFIX, so a bare
+	// `command -v` would miss an install that just succeeded — and so would the terminal launcher.
+	'  [ -n "$p" ] && [ -x "$p/bin/claude" ] && ln -sf "$p/bin/claude" /usr/local/bin/claude 2>/dev/null\n' +
+	'  if command -v claude >/dev/null 2>&1 || [ -x "$p/bin/claude" ]; then exit 0; fi\n' +
+	'fi\n' +
+	'u="${1:-${_REMOTE_USER:-root}}"\n' +
+	'h="$(getent passwd "$u" 2>/dev/null | cut -d: -f6)"; [ -n "$h" ] || h="$HOME"\n' +
+	'f="$(mktemp)"\n' +
+	'if command -v curl >/dev/null 2>&1; then curl -fsSL https://claude.ai/install.sh -o "$f"\n' +
+	'elif command -v wget >/dev/null 2>&1; then wget -qO "$f" https://claude.ai/install.sh\n' +
+	'else echo "no curl/wget to fetch the Claude Code installer" >&2; exit 1; fi\n' +
+	'chmod 0755 "$f"\n' +
+	// -m keeps the HOME set here, so the installer targets the remote user's home, not root's.
+	'if [ "$(id -un)" = "$u" ]; then "$f" >/dev/null 2>&1\n' +
+	'else HOME="$h" su -m "$u" -c "\'$f\'" >/dev/null 2>&1; fi\n' +
+	'rm -f "$f"\n' +
+	// The installer's ~/.local/bin is on no other user's PATH, and often not even on its own.
+	'ln -sf "$h/.local/bin/claude" /usr/local/bin/claude 2>/dev/null || true\n' +
+	'command -v claude >/dev/null 2>&1 || [ -x "$h/.local/bin/claude" ]\n';
+
+const CHECK_SCRIPT = 'command -v claude >/dev/null 2>&1 && echo 1 || echo 0';
+
+/**
+ * The runtime fallback to the build-time `codebay-claude` feature, mirroring tmux/ttyd. Terminal
+ * mode only: there the launcher *is* `claude`, so a missing binary leaves a bare shell — IDE-mode
+ * instances on a project image keep owning their own tooling.
+ */
+export const claudeCodeInstall: Injection = {
+	id: 'claude-code-install',
+	label: 'Claude Code',
+	modes: ['terminal'],
+
+	async apply(target, log) {
+		log('Checking Claude Code is installed…\n');
+		// Omitting remoteUser runs as root, which the global npm install and the symlink need.
+		const install = await execInContainer(
+			{ containerId: target.containerId },
+			{ script: INSTALL_SCRIPT, args: ['claude-install', target.remoteUser ?? ''] }
+		);
+		log(
+			install.ok
+				? '✓ Claude Code available\n'
+				: `⚠ Claude Code install failed: ${install.error} — the terminal opens a plain shell\n`
+		);
+	},
+
+	async check(target) {
+		return checkPresence(target, CHECK_SCRIPT);
+	}
+};

--- a/src/container-injections/injections.isolated.test.ts
+++ b/src/container-injections/injections.isolated.test.ts
@@ -18,6 +18,7 @@ import { claudeTrustConfig, CLAUDE_TRUST_SETTINGS } from './claude-trust.ts';
 import { homedir } from 'node:os';
 import { INSTALL_SCRIPT, TMUX_CONF_LINES } from './tmux.ts';
 import { INSTALL_SCRIPT as TTYD_INSTALL_SCRIPT } from './ttyd.ts';
+import { INSTALL_SCRIPT as CLAUDE_INSTALL_SCRIPT } from './claude-code-install.ts';
 import {
 	CHECK_SCRIPT as EXT_CHECK_SCRIPT,
 	EXTENSION_ID,
@@ -162,6 +163,17 @@ describe('resolveInjections — mode filtering', () => {
 		expect(ids).not.toContain('ttyd');
 	});
 
+	test('claude-code-install is terminal-only and runs before every claude-* step', () => {
+		const terminal = resolveInjections('terminal').map((i) => i.id);
+		expect(terminal).toContain('claude-code-install');
+		// The tail (update, credentials, trust, aliases…) all assume a `claude` binary exists.
+		expect(terminal.indexOf('claude-code-install')).toBeLessThan(
+			terminal.indexOf('claude-code-update')
+		);
+		// IDE mode on a project image keeps deferring tooling to the project.
+		expect(resolveInjections('ide').map((i) => i.id)).not.toContain('claude-code-install');
+	});
+
 	test('mode-agnostic (no argument) keeps every injection', () => {
 		const ids = resolveInjections().map((i) => i.id);
 		expect(ids).toContain('ttyd');
@@ -180,6 +192,31 @@ describe('ttyd injection script', () => {
 		expect(TTYD_INSTALL_SCRIPT).toContain('apt-get');
 		expect(TTYD_INSTALL_SCRIPT).toContain('apk');
 		expect(TTYD_INSTALL_SCRIPT).toContain('releases/latest/download/ttyd.');
+	});
+});
+
+describe('claude-code-install script', () => {
+	test('sniffs first, so an image that already ships Claude Code is left alone', () => {
+		expect(
+			CLAUDE_INSTALL_SCRIPT.startsWith('if command -v claude >/dev/null 2>&1; then exit 0; fi')
+		).toBe(true);
+	});
+
+	test('never installs Node via nvm', () => {
+		// The whole point: the upstream node feature's nvm install aborts on any image that
+		// sets NPM_CONFIG_PREFIX, which is what broke terminal-mode builds.
+		expect(CLAUDE_INSTALL_SCRIPT).not.toContain('nvm');
+		expect(CLAUDE_INSTALL_SCRIPT).toContain('npm install -g @anthropic-ai/claude-code@latest');
+		// The no-Node fallback needs no Node at all.
+		expect(CLAUDE_INSTALL_SCRIPT).toContain('https://claude.ai/install.sh');
+	});
+
+	test('runs the standalone installer as the remote user, not root', () => {
+		// It installs under $HOME, so running as root would strand the binary in /root.
+		expect(CLAUDE_INSTALL_SCRIPT).toContain('u="${1:-${_REMOTE_USER:-root}}"');
+		expect(CLAUDE_INSTALL_SCRIPT).toContain('su -m "$u"');
+		// …and the result has to be on every user's PATH, including root's.
+		expect(CLAUDE_INSTALL_SCRIPT).toContain('ln -sf "$h/.local/bin/claude" /usr/local/bin/claude');
 	});
 });
 

--- a/src/lib/devcontainer.isolated.test.ts
+++ b/src/lib/devcontainer.isolated.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import {
+	mkdtempSync,
+	rmSync,
+	mkdirSync,
+	writeFileSync,
+	readFileSync,
+	existsSync,
+	statSync
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { PUBLISH_HOST } from './config.server.ts';
@@ -462,6 +470,7 @@ describe('writeOverrideConfig terminal mode', () => {
 		await writeOverrideConfig(dir, 8001, [], undefined, 'terminal');
 		const text = readFileSync(join(dir, '.git', 'info', 'exclude'), 'utf8');
 		expect(text).toContain('/.devcontainer/codebay-ttyd/');
+		expect(text).toContain('/.devcontainer/codebay-claude/');
 		expect(text).toContain('/.devcontainer/codebay-terminal.sh');
 	});
 
@@ -475,7 +484,50 @@ describe('writeOverrideConfig terminal mode', () => {
 		const features = readDevcontainer().features;
 		// The launcher *is* `claude`, so unlike IDE mode terminal mode can't defer tooling to the
 		// project's config — a bare shell would defeat the whole "just Claude in a terminal" point.
+		expect(features['./codebay-claude']).toBeDefined();
+		// But not via the upstream features: their nvm-based Node install fails outright on any
+		// project image that sets NPM_CONFIG_PREFIX. The local feature sniffs instead.
+		expect(features['ghcr.io/devcontainers/features/node:1']).toBeUndefined();
+		expect(features['ghcr.io/anthropics/devcontainer-features/claude-code:1.0']).toBeUndefined();
+		// gh is a plain package install with no such hazard, so it stays.
+		expect(features['ghcr.io/devcontainers/features/github-cli:1']).toBeDefined();
+	});
+
+	test('stages the codebay-claude feature with a best-effort, nvm-free install script', async () => {
+		mkdirSync(join(dir, '.devcontainer'), { recursive: true });
+		writeFileSync(
+			join(dir, '.devcontainer', 'devcontainer.json'),
+			JSON.stringify({ image: 'ships/own:1' })
+		);
+		await writeOverrideConfig(dir, 8001, [], undefined, 'terminal');
+		const featureDir = join(dir, '.devcontainer', 'codebay-claude');
+		const meta = JSON.parse(readFileSync(join(featureDir, 'devcontainer-feature.json'), 'utf8'));
+		expect(meta.id).toBe('codebay-claude');
+		const install = readFileSync(join(featureDir, 'install.sh'), 'utf8');
+		expect(install.startsWith('#!/bin/sh\n')).toBe(true);
+		expect(install).toContain('command -v claude');
+		expect(install).not.toContain('nvm');
+		// Wrapped so a failed install can never break the build; the injection retries at boot.
+		expect(install.trimEnd().endsWith('exit 0')).toBe(true);
+		expect(statSync(join(featureDir, 'install.sh')).mode & 0o111).toBeGreaterThan(0);
+	});
+
+	test('uses the upstream Claude features, not the local one, for the default image', async () => {
+		await writeOverrideConfig(dir, 8001, [], undefined, 'terminal');
+		const features = readDevcontainer().features;
 		expect(features['ghcr.io/anthropics/devcontainer-features/claude-code:1.0']).toBeDefined();
-		expect(features['ghcr.io/devcontainers/features/node:1']).toBeDefined();
+		expect(features['./codebay-claude']).toBeUndefined();
+		expect(existsSync(join(dir, '.devcontainer', 'codebay-claude'))).toBe(false);
+	});
+
+	test('never stages the codebay-claude feature in IDE mode', async () => {
+		mkdirSync(join(dir, '.devcontainer'), { recursive: true });
+		writeFileSync(
+			join(dir, '.devcontainer', 'devcontainer.json'),
+			JSON.stringify({ image: 'ships/own:1' })
+		);
+		await writeOverrideConfig(dir, 8001);
+		expect(readDevcontainer().features['./codebay-claude']).toBeUndefined();
+		expect(existsSync(join(dir, '.devcontainer', 'codebay-claude'))).toBe(false);
 	});
 });

--- a/src/lib/devcontainer.server.ts
+++ b/src/lib/devcontainer.server.ts
@@ -4,6 +4,7 @@ import { basename, dirname, join, relative } from 'node:path';
 import { homedir } from 'node:os';
 import { INSTALL_SCRIPT as TMUX_INSTALL_SCRIPT } from '../container-injections/tmux.ts';
 import { INSTALL_SCRIPT as TTYD_INSTALL_SCRIPT } from '../container-injections/ttyd.ts';
+import { INSTALL_SCRIPT as CLAUDE_INSTALL_SCRIPT } from '../container-injections/claude-code-install.ts';
 import { EXTENSION_ID as CLAUDE_CODE_EXTENSION_ID } from '../container-injections/claude-code-ide-extension.ts';
 import {
 	CODE_SERVER_PORT,
@@ -19,7 +20,11 @@ import type { PortForward } from '../types.ts';
 
 const CODE_SERVER_FEATURE = 'ghcr.io/coder/devcontainer-features/code-server:1';
 
-/** Installs the Claude Code CLI into the default image. Needs Node — supplied by NODE_FEATURE. */
+/**
+ * Installs the Claude Code CLI into the default image. Needs Node — supplied by NODE_FEATURE.
+ * Default-image only: NODE_FEATURE installs via nvm, which refuses to run when the image sets
+ * NPM_CONFIG_PREFIX, so a project-supplied image gets the sniffing CLAUDE_FEATURE_DIR instead.
+ */
 const CLAUDE_CODE_FEATURE = 'ghcr.io/anthropics/devcontainer-features/claude-code:1.0';
 
 /** Node.js — required by the Claude Code feature, which no longer bundles it. */
@@ -71,12 +76,32 @@ const TTYD_FEATURE_INSTALL =
 	') || echo "codebay-ttyd: install failed (non-fatal); the manager retries after the container starts"\n' +
 	'exit 0\n';
 
+/** Relative to .devcontainer/. Only written for terminal-mode instances on a project-supplied config. */
+const CLAUDE_FEATURE_DIR = 'codebay-claude';
+
+const CLAUDE_FEATURE_METADATA = {
+	id: 'codebay-claude',
+	version: '1.0.0',
+	name: 'Claude Code (Codebay, best-effort)',
+	description:
+		"Installs Claude Code at image build time when the project's own image doesn't already ship it. Never fails the build."
+};
+
+/** Best-effort like tmux/ttyd: build time is the only reliable moment to fetch in an egress-firewalled container. */
+const CLAUDE_FEATURE_INSTALL =
+	'#!/bin/sh\n' +
+	'(\n' +
+	`${CLAUDE_INSTALL_SCRIPT}\n` +
+	') || echo "codebay-claude: install failed (non-fatal); the manager retries after the container starts"\n' +
+	'exit 0\n';
+
 /** Manager-dropped files the project's own .gitignore won't cover, kept out of git status. */
 const MANAGER_GIT_EXCLUDES = [
 	'/.devcontainer/code-server-settings.json',
 	'/.devcontainer/devcontainer-lock.json',
 	'/.devcontainer/codebay-tmux/',
 	'/.devcontainer/codebay-ttyd/',
+	'/.devcontainer/codebay-claude/',
 	'/.devcontainer/codebay-terminal.sh',
 	'/.vscode/tasks.json'
 ];
@@ -413,18 +438,23 @@ export async function writeOverrideConfig(
 		`./${relative(dirname(target), join(workspaceDir, '.devcontainer', dir))}`;
 	const tmuxFeatureKey = featureKey(TMUX_FEATURE_DIR);
 	const ttydFeatureKey = featureKey(TTYD_FEATURE_DIR);
+	const claudeFeatureKey = featureKey(CLAUDE_FEATURE_DIR);
 
 	// Terminal mode swaps code-server for ttyd; otherwise (tmux, tooling) the two are identical.
-	// Node/Claude/gh: always in terminal mode (its launcher *is* `claude`), else only the default image.
+	// Claude Code: the default image needs the upstream features, while terminal mode on a
+	// project-supplied image gets the local one, which installs only what that image lacks — the
+	// upstream Node feature would run nvm, which any image setting NPM_CONFIG_PREFIX breaks on.
+	// IDE mode on a project config stays hands-off: the project owns its tooling.
+	const needsClaude = isTerminal || !hadConfig;
 	config.features = {
 		...(config.features ?? {}),
 		...(isTerminal
 			? { [ttydFeatureKey]: {} }
 			: { [CODE_SERVER_FEATURE]: { host: '0.0.0.0', port: CODE_SERVER_PORT, auth: 'none' } }),
 		[tmuxFeatureKey]: {},
-		...(isTerminal || !hadConfig
-			? { [NODE_FEATURE]: {}, [CLAUDE_CODE_FEATURE]: {}, [GITHUB_CLI_FEATURE]: {} }
-			: {})
+		...(needsClaude ? { [GITHUB_CLI_FEATURE]: {} } : {}),
+		...(needsClaude && !hadConfig ? { [NODE_FEATURE]: {}, [CLAUDE_CODE_FEATURE]: {} } : {}),
+		...(needsClaude && hadConfig ? { [claudeFeatureKey]: {} } : {})
 	};
 
 	const servedPort = isTerminal ? TTYD_PORT : CODE_SERVER_PORT;
@@ -464,6 +494,8 @@ export async function writeOverrideConfig(
 	}
 
 	await writeTmuxFeature(workspaceDir);
+
+	if (needsClaude && hadConfig) await writeClaudeFeature(workspaceDir);
 
 	await writeLocalGitExclude(workspaceDir);
 
@@ -551,6 +583,19 @@ async function writeTmuxFeature(workspaceDir: string): Promise<void> {
 	const installPath = join(dir, 'install.sh');
 	await writeFile(installPath, TMUX_FEATURE_INSTALL, 'utf8');
 	// writeFile's mode only applies on creation; chmod covers rewrites too.
+	await chmod(installPath, 0o755);
+}
+
+async function writeClaudeFeature(workspaceDir: string): Promise<void> {
+	const dir = join(workspaceDir, '.devcontainer', CLAUDE_FEATURE_DIR);
+	await mkdir(dir, { recursive: true }).catch(() => {});
+	await writeFile(
+		join(dir, 'devcontainer-feature.json'),
+		JSON.stringify(CLAUDE_FEATURE_METADATA, null, 2) + '\n',
+		'utf8'
+	);
+	const installPath = join(dir, 'install.sh');
+	await writeFile(installPath, CLAUDE_FEATURE_INSTALL, 'utf8');
 	await chmod(installPath, 0o755);
 }
 

--- a/src/lib/injections.server.ts
+++ b/src/lib/injections.server.ts
@@ -8,6 +8,7 @@ import { gitIdentity } from '../container-injections/git-identity.ts';
 import { claudeCodeCredentials } from '../container-injections/claude-code-credentials.ts';
 import { claudeCodeCustom } from '../container-injections/claude-code-custom.ts';
 import { claudeCodeIdeExtension } from '../container-injections/claude-code-ide-extension.ts';
+import { claudeCodeInstall } from '../container-injections/claude-code-install.ts';
 import { claudeCodeUpdate } from '../container-injections/claude-code-update.ts';
 import { claudeCodeModels } from '../container-injections/claude-code-models.ts';
 import { githubCredentials } from '../container-injections/github-credentials.ts';
@@ -54,6 +55,8 @@ const BASE_INJECTIONS_HEAD: Injection[] = [
 	tmux,
 	// Terminal-mode only (filtered by resolveInjections); a download, so run it early like tmux.
 	ttyd,
+	// Terminal-mode only, and ahead of every claude-* step in the tail, which all assume a binary.
+	claudeCodeInstall,
 	gitIdentity
 ];
 


### PR DESCRIPTION
## What

Creating a **terminal-mode** instance from a repo that ships its own `devcontainer.json` could fail the image build outright:

```
nvm is not compatible with the "NPM_CONFIG_PREFIX" environment variable: currently set to "/usr/local/share/npm-global"
Failed to install Node.js lts/*
ERROR: Feature "Node.js (via nvm), yarn and pnpm." (ghcr.io/devcontainers/features/node) failed to install!
→ exit code 11
```

`writeOverrideConfig` added the upstream `node:1` + `claude-code:1.0` + `github-cli:1` features whenever `isTerminal || !hadConfig` — so terminal mode injected them even into project-owned images, because its launcher *is* `claude`. The Node feature installs via nvm, which hard-refuses to run when the image sets `NPM_CONFIG_PREFIX`. That env var comes straight from the widely-copied Anthropic sandbox Dockerfile, so **any** repo built on that pattern hits it (reported against `khromov/mochi`). IDE mode was unaffected.

The injection was redundant there anyway: such images already `npm install -g @anthropic-ai/claude-code`.

## How

Gating on `hadConfig` alone would regress terminal mode on project images that *don't* ship Claude, and the host can't sniff ahead of time — a `build.dockerfile` config has no image to inspect at the moment features are chosen. So the sniff happens where the truth exists: **inside the build**, and **at boot**.

- **New local `codebay-claude` feature** replaces the upstream pair for project-supplied configs in terminal mode, mirroring `codebay-tmux`/`codebay-ttyd`: best-effort, wrapped so it can never fail a build.
- **New `src/container-injections/claude-code-install.ts`** holds the one script both use — exit early if `claude` exists → else npm → else the standalone installer (needs no Node at all). Nothing in it touches nvm.
- **Registered as a runtime injection** (`modes: ['terminal']`, ahead of every `claude-*` step, which all assume a binary) as the boot-time fallback, same shape as tmux/ttyd.
- The npm branch **symlinks into `/usr/local/bin`**: an image with its own `NPM_CONFIG_PREFIX` leaves npm's global bin off `PATH`, including the ttyd launcher's, which runs bare `claude`.
- The default image keeps the upstream features. **IDE mode is untouched** — a project config still owns its own tooling there.

## Testing

`bun run checks` — 263 pass, 0 fail; typecheck/eslint/format clean.

Verified on a live daemon with a synthetic repo carrying the same hazard (own Dockerfile + `NPM_CONFIG_PREFIX`):

- **Before/after:** the old config reproduces the nvm failure; the config generated now builds (`"outcome":"success"`) and `devcontainer up` boots, with claude 2.1.226, tmux, ttyd and gh present for both the remote user and root.
- **Real `claudeCodeInstall.apply()` against live containers:** no-op in 83ms where Claude already exists; standalone install (correct owner, on PATH) in a container with no Node at all.
- **Branch coverage in containers:** already-present → no-op; npm path under `NPM_CONFIG_PREFIX`; no-Node standalone path as a non-root user; no-curl/wget → clean non-fatal failure.

New tests cover the local feature being staged + executable, `node:1` staying out of project-supplied terminal configs (the regression guard), the default-image path keeping the upstream features, IDE mode never staging it, the script's branches, and injection ordering.
