### PR TITLE
refactor: simplify the Claude feature branch in writeOverrideConfig

### DIFF
--- a/src/lib/devcontainer.server.ts
+++ b/src/lib/devcontainer.server.ts
@@ -453,8 +453,11 @@ export async function writeOverrideConfig(
 			: { [CODE_SERVER_FEATURE]: { host: '0.0.0.0', port: CODE_SERVER_PORT, auth: 'none' } }),
 		[tmuxFeatureKey]: {},
 		...(needsClaude ? { [GITHUB_CLI_FEATURE]: {} } : {}),
-		...(needsClaude && !hadConfig ? { [NODE_FEATURE]: {}, [CLAUDE_CODE_FEATURE]: {} } : {}),
-		...(needsClaude && hadConfig ? { [claudeFeatureKey]: {} } : {})
+		...(!hadConfig
+			? { [NODE_FEATURE]: {}, [CLAUDE_CODE_FEATURE]: {} }
+			: isTerminal
+				? { [claudeFeatureKey]: {} }
+				: {})
 	};
 
 	const servedPort = isTerminal ? TTYD_PORT : CODE_SERVER_PORT;
@@ -495,7 +498,7 @@ export async function writeOverrideConfig(
 
 	await writeTmuxFeature(workspaceDir);
 
-	if (needsClaude && hadConfig) await writeClaudeFeature(workspaceDir);
+	if (isTerminal && hadConfig) await writeClaudeFeature(workspaceDir);
 
 	await writeLocalGitExclude(workspaceDir);
 


### PR DESCRIPTION
Follow-up to #126 — no behaviour change, and the existing tests cover all three cases unchanged.

The two guards added there overlapped: `needsClaude && !hadConfig` is just `!hadConfig` (no config always needs Claude), and `needsClaude && hadConfig` is just `isTerminal && hadConfig`. Spelling the three cases out as a single chain says what it means:

```
no project config          → upstream NODE + CLAUDE_CODE features
project config + terminal  → local codebay-claude feature
project config + IDE       → nothing (the project owns its tooling)
```

`bun run checks`: 263 pass, 0 fail.
