### PR TITLE
fix: relaunch the terminal when a stopped instance is started again

### DIFF
--- a/src/components/AppShell.svelte
+++ b/src/components/AppShell.svelte
@@ -303,7 +303,11 @@
 					     iframe's own `load` is bounded and gets a plain loader. The terminal has no
 					     `load` event, so once it's mountable its own "connecting…" covers the gap. -->
 					{#if !mountable(inst.id)}
-						<IdeLoader stalledAfterMs={STALLED_AFTER_MS} onoverride={() => forced.add(inst.id)} />
+						<IdeLoader
+							mode={inst.mode}
+							stalledAfterMs={STALLED_AFTER_MS}
+							onoverride={() => forced.add(inst.id)}
+						/>
 					{:else if inst.mode !== 'terminal' && !loadedFrames.has(inst.id)}
 						<IdeLoader />
 					{/if}

--- a/src/components/IdeLoader.svelte
+++ b/src/components/IdeLoader.svelte
@@ -1,14 +1,23 @@
 <script lang="ts">
 	import Button from './Button.svelte';
+	import type { InstanceMode } from '../types.ts';
 
 	// A fixed flip count per tick, rather than a per-bit probability, is what keeps
 	// the cadence visually even; `speed` scales only the interval, never the churn.
 	let {
 		speed = 1,
+		mode = 'ide',
 		// Omit both unless the wait could in principle never end.
 		stalledAfterMs,
 		onoverride
-	}: { speed?: number; stalledAfterMs?: number; onoverride?: () => void } = $props();
+	}: {
+		speed?: number;
+		mode?: InstanceMode;
+		stalledAfterMs?: number;
+		onoverride?: () => void;
+	} = $props();
+
+	const isTerminal = $derived(mode === 'terminal');
 
 	let stalled = $state(false);
 	$effect(() => {
@@ -52,11 +61,14 @@
 		{/each}
 	</div>
 	<div class="label">
-		Loading editor<span class="dot">.</span><span class="dot">.</span><span class="dot">.</span>
+		Loading {isTerminal ? 'terminal' : 'editor'}<span class="dot">.</span><span class="dot">.</span
+		><span class="dot">.</span>
 	</div>
 	{#if stalled}
 		<div class="stalled">
-			<p>Waiting for code-server to answer inside the container.</p>
+			<p>
+				Waiting for {isTerminal ? 'the terminal' : 'code-server'} to answer inside the container.
+			</p>
 			{#if onoverride}
 				<Button size="sm" onclick={onoverride}>Open anyway</Button>
 			{/if}

--- a/src/lib/devcontainer.isolated.test.ts
+++ b/src/lib/devcontainer.isolated.test.ts
@@ -11,7 +11,46 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { PUBLISH_HOST } from './config.server.ts';
-import { readDeclaredContainerPorts, writeOverrideConfig } from './devcontainer.server.ts';
+import {
+	launchCommandFor,
+	readDeclaredContainerPorts,
+	TERMINAL_LAUNCHED_MARKER,
+	writeOverrideConfig
+} from './devcontainer.server.ts';
+
+/**
+ * `relaunchSurface` re-runs these after a plain `docker start`, which never re-runs
+ * postStartCommand. If the two ever fork, a restarted instance boots a different surface than a
+ * freshly provisioned one — so pin them to the same string.
+ */
+describe('launchCommandFor', () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), 'codebay-launch-'));
+	});
+	afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+	const postStart = () =>
+		JSON.parse(readFileSync(join(dir, '.devcontainer', 'devcontainer.json'), 'utf8'))
+			.postStartCommand as string;
+
+	test('terminal mode returns exactly what writeOverrideConfig writes', async () => {
+		await writeOverrideConfig(dir, 8001, [], undefined, 'terminal');
+		expect(postStart()).toContain(launchCommandFor('terminal'));
+	});
+
+	test('ide mode returns exactly what writeOverrideConfig writes', async () => {
+		await writeOverrideConfig(dir, 8001, [], undefined, 'ide');
+		expect(postStart()).toContain(launchCommandFor('ide'));
+	});
+
+	test('the IDE run-once marker has a single definition', async () => {
+		await writeOverrideConfig(dir, 8001, [], undefined, 'ide');
+		const task = readFileSync(join(dir, '.vscode', 'tasks.json'), 'utf8');
+		expect(task).toContain(TERMINAL_LAUNCHED_MARKER);
+	});
+});
 
 describe('readDeclaredContainerPorts', () => {
 	let dir: string;
@@ -432,6 +471,14 @@ describe('writeOverrideConfig terminal mode', () => {
 		expect(cmd).toContain('.devcontainer/codebay-terminal.sh');
 		// No code-server anywhere in a terminal-mode boot.
 		expect(cmd).not.toContain('code-server');
+	});
+
+	test('the launcher bails when ttyd is missing, so a late install needs its own relaunch', async () => {
+		await writeOverrideConfig(dir, 8001, [], undefined, 'terminal');
+		const cmd = readDevcontainer().postStartCommand as string;
+		// postStartCommand runs before the injection that installs ttyd as a fallback, so a failed
+		// build-time install leaves this a no-op — provision() relaunches afterwards to cover it.
+		expect(cmd).toContain('command -v ttyd >/dev/null 2>&1 || exit 0');
 	});
 
 	test('guards the ttyd launch by process name, not by a self-matching cmdline pattern', async () => {

--- a/src/lib/devcontainer.server.ts
+++ b/src/lib/devcontainer.server.ts
@@ -145,6 +145,12 @@ const TMUX_SHELL_SESSION = 'codebay-shell';
 export const INJECTIONS_DONE_FILE = '.codebay-injections-done';
 
 /**
+ * IDE mode's folderOpen task touches this to stay run-once across workspace reloads, but it
+ * outlives a container restart — so a relaunch must clear it or the terminal never reopens.
+ */
+export const TERMINAL_LAUNCHED_MARKER = '.codebay-terminal-launched';
+
+/**
  * An auto-launched `claude` that starts mid-injection reads `~/.claude.json` before the trust
  * keys land and clobbers them on its next rewrite, so hold it until the sentinel appears.
  * Bounded so a failed boot (sentinel never written) still yields a usable terminal.
@@ -188,7 +194,9 @@ const terminalTask = (permissionMode: ClaudePermissionMode) => ({
 		// `"$SHELL"` must reach tmux unexpanded; VS Code would substitute a `${…}` form first.
 		`if command -v tmux >/dev/null 2>&1; then exec tmux new-session -A -s ${TMUX_SESSION} '${WAIT_FOR_INJECTIONS}${WAIT_FOR_IDE_BRIDGE}${SOURCE_INJECTED_ENV}claude ${claudePermissionFlags(permissionMode)}; exec "$SHELL" -l'; fi; ` +
 		// Without tmux there's no run-once gate, and folderOpen re-fires on every workspace load.
-		'MARK="$HOME/.codebay-terminal-launched"; [ -e "$MARK" ] && exit 0; touch "$MARK"; ' +
+		'MARK="$HOME/' +
+		TERMINAL_LAUNCHED_MARKER +
+		'"; [ -e "$MARK" ] && exit 0; touch "$MARK"; ' +
 		WAIT_FOR_INJECTIONS +
 		WAIT_FOR_IDE_BRIDGE +
 		SOURCE_INJECTED_ENV +
@@ -265,6 +273,14 @@ const TTYD_LAUNCH =
 	// both the Claude session and the split view's scratch shell (--writable is covered above).
 	`nohup ttyd --port ${TTYD_PORT} --writable --url-arg ` +
 	`bash \\"$PWD/.devcontainer/${TTYD_LAUNCH_SCRIPT_FILE}\\" >/tmp/ttyd.log 2>&1 &"`;
+
+/**
+ * The launcher `postStartCommand` runs, exposed so a host-side relaunch can reuse the exact
+ * string rather than growing a second, driftable copy of "how the served surface is started".
+ */
+export function launchCommandFor(mode: InstanceMode): string {
+	return mode === 'terminal' ? TTYD_LAUNCH : CODE_SERVER_LAUNCH;
+}
 
 export async function devcontainerCliAvailable(): Promise<boolean> {
 	return (await spawnCapture([devcontainerBin(), '--version'])) !== null;
@@ -495,7 +511,7 @@ export async function writeOverrideConfig(
 	runArgs.add(HOST_GATEWAY_ARG);
 	config.runArgs = [...runArgs];
 
-	const launch = isTerminal ? TTYD_LAUNCH : CODE_SERVER_LAUNCH;
+	const launch = launchCommandFor(mode);
 	const existing = config.postStartCommand;
 	config.postStartCommand =
 		typeof existing === 'string' && existing.trim() ? `${existing} && ${launch}` : launch;

--- a/src/lib/health.server.ts
+++ b/src/lib/health.server.ts
@@ -1,6 +1,6 @@
 import { type InstanceRow } from './db.server.ts';
 import { isRunning, publishedContainerPorts } from './docker.server.ts';
-import { broadcastHealth } from './instances.server.ts';
+import { broadcastHealth, relaunchSurface } from './instances.server.ts';
 import { resolveInjections } from './injections.server.ts';
 import type { InstanceHealth } from '../types.ts';
 
@@ -15,7 +15,8 @@ interface Monitor {
 const globalForHealth = globalThis as unknown as { __codebayHealth?: Map<string, Monitor> };
 const monitors: Map<string, Monitor> = (globalForHealth.__codebayHealth ??= new Map());
 
-async function codeServerAccessible(port: number): Promise<boolean> {
+/** Named for what it measures — the served surface is ttyd in terminal mode, code-server in IDE. */
+export async function surfaceAccessible(port: number): Promise<boolean> {
 	try {
 		// Any HTTP response at all (200/302/401/…) means the server is listening.
 		await fetch(`http://127.0.0.1:${port}/`, { signal: AbortSignal.timeout(2000) });
@@ -38,7 +39,7 @@ async function check(row: InstanceRow): Promise<InstanceHealth> {
 	// Probes as the recorded remote user, so `$HOME` resolves to the one the injection wrote to.
 	const target = { containerId: row.container_id, remoteUser: row.remote_user, instance: row };
 	const [accessible, openPorts, injectionResults] = await Promise.all([
-		codeServerAccessible(row.host_port),
+		surfaceAccessible(row.host_port),
 		publishedContainerPorts(row.container_id),
 		Promise.all(
 			resolveInjections(row.mode)
@@ -72,7 +73,17 @@ function startHealthMonitor(row: InstanceRow): Monitor {
 	if (existing) return existing;
 	const mon: Monitor = { snapshot: null, timer: setInterval(() => void tick(row), REFRESH_MS) };
 	monitors.set(row.id, mon);
-	void tick(row); // seed the first snapshot rather than making the UI wait a full interval
+	// Seed a snapshot rather than making the UI wait a full interval, then use it to decide
+	// whether this container needs a relaunch.
+	void tick(row).then(async () => {
+		const seeded = monitors.get(row.id)?.snapshot;
+		if (!seeded?.containerRunning || seeded.codeServerAccessible) return;
+		// A live container with a dead port means postStartCommand never re-ran — it only fires
+		// under `devcontainer up`. Covers starts codebay didn't perform (a daemon restart, a bare
+		// `docker start`); once per monitor, so a genuinely wedged container isn't exec'd in a loop.
+		await relaunchSurface(row).catch(() => undefined);
+		void tick(row);
+	});
 	return mon;
 }
 

--- a/src/lib/instances-lifecycle.isolated.test.ts
+++ b/src/lib/instances-lifecycle.isolated.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { PassThrough } from 'node:stream';
+import { deleteInstanceRow, insertInstance, type InstanceRow } from './db.server.ts';
+import { relaunchSurface, startInstance } from './instances.server.ts';
+
+/**
+ * `getDocker()` resolves a client pinned to `globalThis.__codebayDocker`; seeding that slot
+ * runs the lifecycle against an in-memory stub, with no daemon involved.
+ */
+const g = globalThis as unknown as { __codebayDocker?: Promise<unknown> };
+
+interface ExecCall {
+	Cmd: string[];
+	User: string;
+}
+
+function fakeDocker(opts: { exitCode?: number; startFails?: boolean } = {}) {
+	const calls = { execs: [] as ExecCall[], started: 0 };
+
+	const container = {
+		start: async () => {
+			calls.started++;
+			if (opts.startFails) throw Object.assign(new Error('http 500'), { statusCode: 500 });
+		},
+		// Reported as stopped so the reconcile that follows never spins up a health monitor.
+		inspect: async () => ({ State: { Running: false } }),
+		exec: async (cfg: ExecCall) => {
+			calls.execs.push(cfg);
+			return {
+				start: async () => new PassThrough().end(),
+				// The real demuxStream puts the stream in flowing mode, which is what lets 'end' fire.
+				modem: { demuxStream: (s: PassThrough) => s.resume() },
+				inspect: async () => ({ ExitCode: opts.exitCode ?? 0 })
+			};
+		}
+	};
+
+	g.__codebayDocker = Promise.resolve({ getContainer: () => container });
+	return calls;
+}
+
+const realFetch = globalThis.fetch;
+/** Drives `surfaceAccessible`: resolving means the port answers, rejecting means it's dead. */
+function stubSurface(reachable: boolean) {
+	globalThis.fetch = (async () => {
+		if (!reachable) throw new Error('ECONNREFUSED');
+		return new Response('ok');
+	}) as unknown as typeof fetch;
+}
+
+let seq = 0;
+function seed(overrides: Partial<InstanceRow> = {}): InstanceRow {
+	const row: InstanceRow = {
+		id: `relaunch-${++seq}`,
+		name: `relaunch-${seq}`,
+		source_path: '/src',
+		workspace_path: '/ws',
+		host_port: 8001,
+		container_id: 'container-abc',
+		remote_workspace_folder: '/workspace',
+		status: 'stopped',
+		error: null,
+		created_at: Date.now(),
+		bridge_token: 'tok',
+		remote_user: 'node',
+		image_source: 'local',
+		mode: 'terminal',
+		terminal_split: 0,
+		...overrides
+	};
+	insertInstance(row);
+	return row;
+}
+
+const scriptOf = (call: ExecCall) => call.Cmd[2]!;
+
+afterEach(() => {
+	globalThis.fetch = realFetch;
+	g.__codebayDocker = undefined;
+});
+
+describe('relaunchSurface', () => {
+	beforeEach(() => stubSurface(false));
+
+	test('relaunches ttyd as the remote user, from the workspace folder', async () => {
+		const calls = fakeDocker();
+		await relaunchSurface(seed());
+
+		expect(calls.execs).toHaveLength(1);
+		const call = calls.execs[0]!;
+		expect(call.User).toBe('node');
+		expect(call.Cmd.slice(0, 2)).toEqual(['bash', '-lc']);
+		expect(scriptOf(call)).toContain(`cd '/workspace' || exit 1`);
+		expect(scriptOf(call)).toContain('ttyd --port 7681');
+	});
+
+	test('skips the launch when the surface already answers', async () => {
+		stubSurface(true);
+		const calls = fakeDocker();
+		await relaunchSurface(seed());
+		// Terminal mode has nothing else to do, so the exec is skipped outright.
+		expect(calls.execs).toHaveLength(0);
+	});
+
+	test('clears the IDE run-once marker even when code-server is already back up', async () => {
+		stubSurface(true);
+		const calls = fakeDocker();
+		// The code-server feature's entrypoint restarts the daemon on its own, but the marker
+		// still has to go or the folderOpen Claude terminal never reopens.
+		await relaunchSurface(seed({ mode: 'ide' }));
+
+		expect(calls.execs).toHaveLength(1);
+		expect(scriptOf(calls.execs[0]!)).toContain('rm -f "$HOME/.codebay-terminal-launched"');
+		expect(scriptOf(calls.execs[0]!)).not.toContain('code-server --bind-addr');
+	});
+
+	test('never clears the injections sentinel, whose files outlive the restart', async () => {
+		const calls = fakeDocker();
+		await relaunchSurface(seed());
+		expect(scriptOf(calls.execs[0]!)).not.toContain('codebay-injections-done');
+	});
+
+	test('falls back to root when no remote user was recorded', async () => {
+		const calls = fakeDocker();
+		await relaunchSurface(seed({ remote_user: null }));
+		expect(calls.execs[0]!.User).toBe('root');
+	});
+
+	test('emits no cd when the remote workspace folder is unknown', async () => {
+		const calls = fakeDocker();
+		await relaunchSurface(seed({ remote_workspace_folder: null }));
+		expect(scriptOf(calls.execs[0]!)).not.toContain('cd ');
+	});
+
+	test('single-quote-escapes a workspace folder that contains a quote', async () => {
+		const calls = fakeDocker();
+		await relaunchSurface(seed({ remote_workspace_folder: "/w'x" }));
+		expect(scriptOf(calls.execs[0]!)).toContain(`cd '/w'\\''x' || exit 1`);
+	});
+
+	test('is a no-op for a row with no container', async () => {
+		const calls = fakeDocker();
+		await relaunchSurface(seed({ container_id: null }));
+		expect(calls.execs).toHaveLength(0);
+	});
+});
+
+describe('startInstance', () => {
+	beforeEach(() => stubSurface(false));
+
+	test('relaunches the surface after starting the container', async () => {
+		const calls = fakeDocker();
+		const row = seed();
+		const result = await startInstance(row.id);
+
+		expect(calls.started).toBe(1);
+		expect(calls.execs).toHaveLength(1);
+		expect(scriptOf(calls.execs[0]!)).toContain('ttyd --port 7681');
+		expect(result.status).toBe('running');
+		deleteInstanceRow(row.id);
+	});
+
+	test('a failed relaunch leaves the instance running rather than erroring it', async () => {
+		const calls = fakeDocker({ exitCode: 1 });
+		const row = seed();
+		const result = await startInstance(row.id);
+
+		expect(calls.execs).toHaveLength(1);
+		// The container genuinely is up; the health row is what reports the dead surface.
+		expect(result.status).toBe('running');
+		expect(result.error).toBeNull();
+		deleteInstanceRow(row.id);
+	});
+
+	test('does not attempt a relaunch when the container fails to start', async () => {
+		const calls = fakeDocker({ startFails: true });
+		const row = seed();
+		const result = await startInstance(row.id);
+
+		expect(calls.execs).toHaveLength(0);
+		expect(result.status).toBe('error');
+		deleteInstanceRow(row.id);
+	});
+
+	test('rejects an instance that has no container yet', async () => {
+		fakeDocker();
+		const row = seed({ container_id: null });
+		await expect(startInstance(row.id)).rejects.toThrow('no container');
+	});
+});

--- a/src/lib/instances.server.ts
+++ b/src/lib/instances.server.ts
@@ -41,17 +41,25 @@ import {
 	devcontainerCliAvailable,
 	devcontainerUp,
 	INJECTIONS_DONE_FILE,
+	launchCommandFor,
 	readDeclaredContainerPorts,
+	TERMINAL_LAUNCHED_MARKER,
 	writeOverrideConfig
 } from './devcontainer.server.ts';
 import { writeContainerFile } from './container-files.server.ts';
+import { execInContainer } from './exec.server.ts';
 import { clearAttention, getAttention } from './bridge.server.ts';
 import { proxyPathFor } from './proxy.server.ts';
 import { resolveInjections } from './injections.server.ts';
 import { cloneRepo, readGitBranch } from './git.server.ts';
 import { isRepoUrl, parseRepoUrl } from './repo-url.ts';
 import { getClaudePermissionMode } from '../container-injections/claude-permission-mode.ts';
-import { currentHealthSnapshots, stopHealthMonitor, syncHealthMonitors } from './health.server.ts';
+import {
+	currentHealthSnapshots,
+	stopHealthMonitor,
+	surfaceAccessible,
+	syncHealthMonitors
+} from './health.server.ts';
 import { pickFreePort } from './ports.server.ts';
 import type { ServerWebSocket } from 'bun';
 import {
@@ -315,6 +323,9 @@ async function seedDeclaredPorts(row: InstanceRow): Promise<void> {
 	}
 }
 
+const surfaceLabel = (mode: InstanceMode) =>
+	mode === 'terminal' ? 'ttyd terminal' : 'code-server';
+
 /** Never re-copies the workspace, so in-container edits survive a rebuild. */
 async function provision(row: InstanceRow, opts: { noCache?: boolean } = {}): Promise<void> {
 	try {
@@ -322,8 +333,7 @@ async function provision(row: InstanceRow, opts: { noCache?: boolean } = {}): Pr
 			container_port: f.container_port,
 			host_port: f.host_port
 		}));
-		const surface = row.mode === 'terminal' ? 'ttyd terminal' : 'code-server';
-		appendLog(row.id, `Injecting ${surface} (host port ${row.host_port})\n`);
+		appendLog(row.id, `Injecting ${surfaceLabel(row.mode)} (host port ${row.host_port})\n`);
 		const defaultImage = getOption('default_image') ?? DEFAULT_IMAGE;
 		const { imageSource } = await writeOverrideConfig(
 			row.workspace_path,
@@ -382,6 +392,11 @@ async function provision(row: InstanceRow, opts: { noCache?: boolean } = {}): Pr
 		await writeContainerFile(target, { dir: '$HOME', name: INJECTIONS_DONE_FILE }, 'done\n').catch(
 			() => undefined
 		);
+
+		// postStartCommand ran before the injections above, and its launcher bails when the binary
+		// is missing — so a container whose build-time ttyd install failed got it too late to be
+		// started. No-ops (one accessibility probe) whenever postStart already brought the port up.
+		await relaunchSurface(row);
 
 		appendLog(row.id, `\n✓ Instance running — open it via the proxy at ${proxyPathFor(row.id)}\n`);
 		triggerReconcile();
@@ -581,11 +596,50 @@ export function rebuildRunningInstancesNoCache(): number {
 	return running.length;
 }
 
+/** Single-quote a path for the shell, so a workspace folder with spaces survives the `cd`. */
+function quote(value: string): string {
+	return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+/**
+ * `postStartCommand` is a devcontainer-CLI lifecycle hook, not a container entrypoint, so a plain
+ * `docker start` never re-runs it and the ttyd daemon it backgrounded is gone. IDE mode only
+ * survives because the code-server feature ships an entrypoint of its own; ttyd has no equivalent.
+ * Both launchers are pgrep-guarded, so re-running one against a healthy container is a no-op.
+ */
+export async function relaunchSurface(row: InstanceRow): Promise<void> {
+	if (!row.container_id) return;
+
+	const steps: string[] = [];
+	// The folderOpen task's run-once gate is meant to span one container run, but the marker file
+	// outlives it — left in place, a restarted IDE container never reopens the Claude terminal.
+	if (row.mode !== 'terminal') steps.push(`rm -f "$HOME/${TERMINAL_LAUNCHED_MARKER}"`);
+	// code-server comes back on its own (its feature ships a container entrypoint), so only launch
+	// a surface that is actually down rather than racing the entrypoint for the port.
+	if (!(await surfaceAccessible(row.host_port))) steps.push(launchCommandFor(row.mode));
+	if (!steps.length) return;
+
+	// Both launchers resolve paths off `$PWD`, which under postStartCommand is the workspace
+	// folder; an exec only inherits the image's WorkingDir, so re-establish it explicitly.
+	const cd = row.remote_workspace_folder
+		? `cd ${quote(row.remote_workspace_folder)} || exit 1; `
+		: '';
+	const res = await execInContainer(
+		{ containerId: row.container_id, remoteUser: row.remote_user },
+		{ script: cd + steps.join('; ') }
+	);
+	if (!res.ok) {
+		appendLog(row.id, `⚠ Could not relaunch ${surfaceLabel(row.mode)}: ${res.error}\n`);
+	}
+}
+
 export async function startInstance(id: string): Promise<InstanceRow> {
 	const row = getInstance(id);
 	if (!row) throw new Error('Instance not found');
 	if (!row.container_id) throw new Error('Instance has no container yet');
 	const ok = await startContainer(row.container_id);
+	// Awaited so the first health tick after the reconcile below already sees a listening port.
+	if (ok) await relaunchSurface(row);
 	updateInstance(id, {
 		status: ok ? 'running' : 'error',
 		error: ok ? null : 'Failed to start container'

--- a/src/lib/proxy.server.ts
+++ b/src/lib/proxy.server.ts
@@ -74,10 +74,10 @@ async function proxyHttp(event: MochiApiEvent, port: number, rest: string): Prom
 			duplex: 'half'
 		});
 	} catch (err) {
-		// Usually just code-server not having bound its port yet; letting it escape would
+		// Usually just the served surface not having bound its port yet; letting it escape would
 		// render a 500 stack trace inside the IDE iframe.
 		console.warn(`[proxy] upstream 127.0.0.1:${port}${rest} unreachable:`, (err as Error).message);
-		return new Response('code-server is not accepting connections yet', {
+		return new Response('The instance is not accepting connections yet', {
 			status: 503,
 			headers: { 'retry-after': '1', 'cache-control': 'no-store' }
 		});


### PR DESCRIPTION
## The bug

Stopping and starting a **terminal-mode** instance left it permanently broken: the IDE tab sat on "Loading editor…" forever, and clicking **Open anyway** dropped you into a terminal stuck on "connecting…". A freshly created instance was fine — only the stop/start cycle broke it.

## Root cause

`ttyd` is launched **only** from the devcontainer `postStartCommand` (`TTYD_LAUNCH`) as `nohup ttyd … &`. But `startInstance` is a bare dockerode `container.start()`, and `postStartCommand` is a devcontainer-CLI lifecycle hook rather than a container entrypoint — so a plain `docker start` never re-runs it. ttyd was never relaunched.

**IDE mode masked the identical gap**: the upstream coder code-server feature installs `/usr/local/bin/code-server-entrypoint` into the container's ENTRYPOINT, so code-server restarts itself on every start. codebay's own local features (`codebay-ttyd`, `codebay-tmux`, `codebay-claude`) declare no entrypoint.

Confirmed on a real stopped-then-started container:

```
$ docker exec <c> ps aux
node  7  bash /usr/local/bin/code-server-entrypoint      ← code-server restarted itself
node  9  /usr/lib/code-server … --bind-addr 0.0.0.0:8080
                                                         ← no ttyd process at all
$ docker exec <c> ss -ltn
LISTEN 0.0.0.0:8080                                      ← only code-server; 7681 dead
$ docker exec <c> command -v ttyd
/usr/local/bin/ttyd                                      ← binary survives; the process doesn't
```

Everything file-shaped survives a stop/start (the ttyd binary, injected credentials, the injections sentinel). Everything process-shaped does not (ttyd, the tmux server, the `claude` inside it) — and nothing short of a rebuild restarted them.

That produced both symptoms: `surfaceAccessible` fetches `127.0.0.1:<host_port>` and failed forever, so `AppShell`'s `everReady` gate never opened; forcing the mount then left `TerminalPane` retrying a WebSocket the proxy couldn't route.

## The fix

Re-run the mode's launch command inside the already-started container, reusing the **exact** string `postStartCommand` uses (`launchCommandFor(mode)`), so the two can't drift — there's a test pinning them together.

`relaunchSurface(row)` execs it via the existing `execInContainer`, as the row's `remote_user`, `cd`'d to `remote_workspace_folder` (both launchers resolve paths off `$PWD`, which a `docker exec` doesn't inherit). It's called from:

- **`startInstance`**, awaited, so the first health tick after the reconcile already sees a listening port;
- **the health monitor's stopped→running transition**, once per monitor and only when the container is up but the port is dead — covering starts codebay didn't perform (a Docker daemon restart, a manual `docker start`, or codebay having been down at the time);
- **the end of `provision()`** — see below.

Both launchers are already idempotent (`pgrep -x ttyd` / the code-server guard), and `relaunchSurface` additionally skips the launch when the port already answers, so it never races the code-server entrypoint.

### A first-boot bug found along the way

`provision()` runs `postStartCommand` (via `devcontainerUp`) **before** the injection loop, and `TTYD_LAUNCH` opens with `command -v ttyd || exit 0`. So when the best-effort build-time `codebay-ttyd` feature install fails — its whole design is to swallow errors for egress-firewalled containers — postStart no-ops, the `ttyd` injection then installs the binary, and nothing ever launched it. The terminal was dead on **first** boot, not just after a restart.

The health-monitor self-heal alone didn't cover this: status flips to `running` before injections finish, so a periodic reconcile can start the monitor mid-provision and burn its single attempt while ttyd still isn't installed. Hence the additional `relaunchSurface(row)` at the end of `provision()`, after the injections. It no-ops via the accessibility probe whenever `postStartCommand` already brought the port up.

### Alongside

- **Clear `~/.codebay-terminal-launched` on relaunch.** IDE mode's folderOpen task uses it as a run-once gate meant to span one container run, but the marker file outlived it — so on tmux-less images the Claude terminal never reopened after a stop/start.
- **Stop showing code-server wording to terminal users** — `IdeLoader` now says "Loading terminal…" / "Waiting for the terminal to answer inside the container", and the proxy's 503 is mode-agnostic.
- Renamed the private `codeServerAccessible` probe to `surfaceAccessible` (the `InstanceHealth` field name is unchanged, to keep this diff scoped).

## Verification

`bun run checks` — 0 typecheck errors, 279 tests pass.

New `src/lib/instances-lifecycle.isolated.test.ts` (12 tests, dockerode stubbed via `globalThis.__codebayDocker`) covers the exec's script/user/cwd, the escape of a quoted workspace path, the skip-when-reachable path, the IDE marker clear, that the injections sentinel is never touched, and that a failed relaunch leaves the instance `running` rather than erroring it. `devcontainer.isolated.test.ts` gains the anti-drift assertions.

Verified live against a real daemon:

- Stop → Start on a terminal instance: ttyd relaunches, 7681 listening, host port returns 200, health reports `codeServerAccessible=true`, and the actual `tty` WebSocket opens and receives a frame.
- Pressing Start twice still leaves exactly one ttyd.
- Booting the server against an already-broken (externally started) container self-healed it with no UI action.
- A full rebuild (fresh container) yields exactly one ttyd — the added provision-time call correctly short-circuits — and stop/start on that new container works end to end.

## Follow-ups, not in this PR

- **`CODE_SERVER_LAUNCH`'s guard is broken.** `pgrep -f 'code-server.*8080'` matches the launching `bash -c`'s own cmdline, so it fires unconditionally and the `nohup` never runs — the same defect fixed for ttyd in 9cfbe13, still present on the code-server side. Verified in-container with a pattern matching no real process: the guard still fired. Invisible today only because the feature entrypoint does the work. Fixing it here would open a genuine double-launch race against that entrypoint for no visible gain.
- **A restart still loses the Claude conversation.** The tmux server dies with the container, so `tmux new-session -A` creates a fresh session. The instance now looks fully healthy while the session is gone, which is arguably more surprising than it never coming back.
- **`writeOverrideConfig` stacks launchers across rebuilds.** It appends `&& <launch>` to the `postStartCommand` it wrote last rebuild and spreads over stale `features`, reading back the copy it wrote itself. A live `mode='terminal'` instance still carried the code-server feature and an obsolete code-server launcher from an older codebay version.
- **Giving `codebay-ttyd` its own ENTRYPOINT** would make ttyd restart-safe by construction, including when codebay itself is down. It has zero retroactive effect (existing containers have frozen ENTRYPOINTs) and would still need this host-side path as the migration route, so it's a complement rather than a replacement.