### PR TITLE
fix: stop stranding instances on host ports taken over outside Docker

### DIFF
--- a/src/lib/db.server.ts
+++ b/src/lib/db.server.ts
@@ -143,7 +143,9 @@ const UPDATABLE_COLUMNS = [
 	'error',
 	'remote_user',
 	'image_source',
-	'terminal_split'
+	'terminal_split',
+	// Reassigned when a rebuild finds the recorded port taken over on the host.
+	'host_port'
 ] as const;
 
 type UpdatableColumn = (typeof UPDATABLE_COLUMNS)[number];

--- a/src/lib/devcontainer.isolated.test.ts
+++ b/src/lib/devcontainer.isolated.test.ts
@@ -48,6 +48,15 @@ describe('launchCommandFor', () => {
 		expect(postStart()).toContain(launchCommandFor('ide'));
 	});
 
+	test('guards the code-server launch by port, not by a self-matching cmdline pattern', async () => {
+		await writeOverrideConfig(dir, 8001, [], undefined, 'ide');
+		// Any `pgrep -f` pattern matching a code-server daemon also matches this launcher's own
+		// argv (it carries the nohup line), so a cmdline guard fires every time and the fallback
+		// launch never runs — leaving no recovery if the feature's entrypoint ever fails.
+		expect(postStart()).toContain('(exec 3<>/dev/tcp/127.0.0.1/8080)');
+		expect(postStart()).not.toContain('pgrep -f');
+	});
+
 	test('the IDE run-once marker has a single definition', async () => {
 		await writeOverrideConfig(dir, 8001, [], undefined, 'ide');
 		const task = readFileSync(join(dir, '.vscode', 'tasks.json'), 'utf8');

--- a/src/lib/devcontainer.server.ts
+++ b/src/lib/devcontainer.server.ts
@@ -233,7 +233,11 @@ function codeServerLaunch(blockingExtInstall: boolean): string {
 		(blockingExtInstall ? CODE_SERVER_INSTALL_EXT_BLOCKING : '') +
 		// The bare default image may not export SHELL, which the Terminal task needs.
 		`export SHELL=\\"\${SHELL:-/bin/bash}\\"; ` +
-		`pgrep -f 'code-server.*${CODE_SERVER_PORT}' >/dev/null 2>&1 || ` +
+		// Probes the port rather than the process list: every `pgrep -f` pattern that matches a
+		// code-server daemon also matches this very shell (its own argv carries the nohup line
+		// below), so a cmdline guard would skip the launch every time. Bracketing can't escape it
+		// either — the payload text itself matches.
+		`(exec 3<>/dev/tcp/127.0.0.1/${CODE_SERVER_PORT}) 2>/dev/null || ` +
 		`nohup code-server --bind-addr 0.0.0.0:${CODE_SERVER_PORT} --auth none ` +
 		`--disable-workspace-trust \\"$PWD\\" >/tmp/code-server.log 2>&1 &` +
 		(blockingExtInstall ? '' : ` ${CODE_SERVER_INSTALL_EXT}`) +

--- a/src/lib/instances.server.ts
+++ b/src/lib/instances.server.ts
@@ -60,7 +60,7 @@ import {
 	surfaceAccessible,
 	syncHealthMonitors
 } from './health.server.ts';
-import { pickFreePort } from './ports.server.ts';
+import { isHostPortBindable, pickBindablePort } from './ports.server.ts';
 import type { ServerWebSocket } from 'bun';
 import {
 	isInstanceFilter,
@@ -264,7 +264,10 @@ async function allocatePort(): Promise<number> {
 	for (const [port, reservedAt] of reservedPorts) {
 		if (dbPorts.has(port) || now - reservedAt > RESERVATION_TTL_MS) reservedPorts.delete(port);
 	}
-	const port = pickFreePort([dbPorts, dockerPorts, new Set(reservedPorts.keys())]);
+	const port = await pickBindablePort(
+		[dbPorts, dockerPorts, new Set(reservedPorts.keys())],
+		isHostPortBindable
+	);
 	reservedPorts.set(port, now);
 	return port;
 }
@@ -333,9 +336,29 @@ async function seedDeclaredPorts(row: InstanceRow): Promise<void> {
 const surfaceLabel = (mode: InstanceMode) =>
 	mode === 'terminal' ? 'ttyd terminal' : 'code-server';
 
+/**
+ * Moves an instance off a host port that something outside Docker has taken over, which otherwise
+ * strands it forever — the container publishes fine but nothing reaches it from the host. Requires
+ * the port to be *both* unbindable and dead, because a rebuild doesn't stop the old container
+ * first: a healthy instance's port is always unbindable here, and its surface still answers.
+ */
+async function rescueHijackedPort(row: InstanceRow): Promise<void> {
+	if (await isHostPortBindable(row.host_port)) return;
+	if (await surfaceAccessible(row.host_port)) return;
+	const stale = row.host_port;
+	const port = await allocatePort();
+	updateInstance(row.id, { host_port: port });
+	row.host_port = port;
+	appendLog(
+		row.id,
+		`⚠ Host port ${stale} is held by another process and isn't reachable — moving to ${port}\n`
+	);
+}
+
 /** Never re-copies the workspace, so in-container edits survive a rebuild. */
 async function provision(row: InstanceRow, opts: { noCache?: boolean } = {}): Promise<void> {
 	try {
+		await rescueHijackedPort(row);
 		const forwards = listForwards(row.id).map((f) => ({
 			container_port: f.container_port,
 			host_port: f.host_port
@@ -625,7 +648,8 @@ function quote(value: string): string {
  * `postStartCommand` is a devcontainer-CLI lifecycle hook, not a container entrypoint, so a plain
  * `docker start` never re-runs it and the ttyd daemon it backgrounded is gone. IDE mode only
  * survives because the code-server feature ships an entrypoint of its own; ttyd has no equivalent.
- * Both launchers are pgrep-guarded, so re-running one against a healthy container is a no-op.
+ * Both launchers are guarded (ttyd by process name, code-server by its port), so re-running one
+ * against a healthy container is a no-op.
  */
 export async function relaunchSurface(row: InstanceRow): Promise<void> {
 	if (!row.container_id) return;

--- a/src/lib/ports.isolated.test.ts
+++ b/src/lib/ports.isolated.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { PORT_BASE, PORT_MAX } from './config.server.ts';
-import { pickFreePort } from './ports.server.ts';
+import { pickBindablePort, pickFreePort } from './ports.server.ts';
 
 describe('pickFreePort', () => {
 	test('returns PORT_BASE when nothing is in use', () => {
@@ -21,5 +21,37 @@ describe('pickFreePort', () => {
 		const all = new Set<number>();
 		for (let port = PORT_BASE; port <= PORT_MAX; port++) all.add(port);
 		expect(() => pickFreePort([all])).toThrow('No free host ports available.');
+	});
+});
+
+describe('pickBindablePort', () => {
+	// A listener the DB and Docker know nothing about — the case that stranded an instance on a
+	// port the VM's forwarder could never bind.
+	const squatting = (...ports: number[]) => {
+		const held = new Set(ports);
+		return async (port: number) => !held.has(port);
+	};
+
+	test('returns the first candidate the host can actually bind', async () => {
+		expect(await pickBindablePort([], squatting())).toBe(PORT_BASE);
+	});
+
+	test('skips a run of ports held outside Docker', async () => {
+		const isBindable = squatting(PORT_BASE, PORT_BASE + 1, PORT_BASE + 2);
+		expect(await pickBindablePort([], isBindable)).toBe(PORT_BASE + 3);
+	});
+
+	test('skips ports the union rejects and ports the host rejects together', async () => {
+		const used = new Set([PORT_BASE]);
+		expect(await pickBindablePort([used], squatting(PORT_BASE + 1))).toBe(PORT_BASE + 2);
+	});
+
+	test('throws once every port is used or unbindable', async () => {
+		const all = new Set<number>();
+		for (let port = PORT_BASE + 1; port <= PORT_MAX; port++) all.add(port);
+		// Only PORT_BASE survives the union, and the host holds it too.
+		await expect(pickBindablePort([all], squatting(PORT_BASE))).rejects.toThrow(
+			'No free host ports available.'
+		);
 	});
 });

--- a/src/lib/ports.server.ts
+++ b/src/lib/ports.server.ts
@@ -7,3 +7,34 @@ export function pickFreePort(usedSets: ReadonlySet<number>[]): number {
 	}
 	throw new Error('No free host ports available.');
 }
+
+/**
+ * A listener outside Docker's view is invisible to the DB/Docker union — and on a VM-backed daemon
+ * the collision never surfaces as an error, because the `-p` bind happens inside the VM where the
+ * port is free while the host-side forward fails (colima logs that as a warning). Claiming the port
+ * ourselves first is the only way the collision reaches us.
+ */
+export async function isHostPortBindable(port: number): Promise<boolean> {
+	try {
+		// Loopback specifically: it's where code-server is always published, and a wildcard squatter
+		// blocks this bind too, so the one probe covers both.
+		const server = Bun.listen({ hostname: '127.0.0.1', port, socket: { data() {} } });
+		server.stop(true);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/** Takes the probe as a parameter so the scan is testable without binding real sockets. */
+export async function pickBindablePort(
+	usedSets: ReadonlySet<number>[],
+	isBindable: (port: number) => Promise<boolean>
+): Promise<number> {
+	const rejected = new Set<number>();
+	for (;;) {
+		const port = pickFreePort([...usedSets, rejected]);
+		if (await isBindable(port)) return port;
+		rejected.add(port);
+	}
+}


### PR DESCRIPTION
## What broke

An instance reported a failing code-server health check and served `The instance is not accepting connections yet` through the proxy. The container was never at fault — `code-server 4.129.0` was listening on `0.0.0.0:8080` inside it and answered `302` to an in-container probe.

Host port 8021 was held by a **process outside Docker**. Colima's log records the collision and swallows it:

```
ssh … -O forward -L 127.0.0.1:8021:127.0.0.1:8021 … exit status 255
warning: failed to set up forwarding tcp port 8021 (negligible if already forwarded)
```

`docker run -p 127.0.0.1:8021:8080` still succeeded, because the real bind happens *inside* the Lima VM where 8021 is free. The host side was never forwarded, so the health probe and the proxy both hit the squatter, which accepts the connection then resets it (`curl` exit 56). The instance was stranded permanently, with no error anywhere explaining why.

## Fixes

**1. The allocator never asked the host OS.** `allocatePort()` unioned DB rows, Docker-published ports and in-flight reservations — a non-Docker listener is invisible to all three. `pickBindablePort` now probes each candidate with a real `Bun.listen` bind before handing it out.

`provision()` also re-validates the recorded port so **rebuild is the recovery path** for an already-stranded instance. A port is only reassigned when it is *both* unbindable and dead: a rebuild doesn't stop the old container first, so a healthy instance's port is always unbindable at that moment — but its surface still answers, so it keeps its port.

**2. A latent bug found while tracing the boot path.** The launcher guarded with `pgrep -f 'code-server.*8080'`, which matches the launching shell's *own* command line — its argv carries the `nohup code-server --bind-addr 0.0.0.0:8080` text it is searching for. Verified live: the guard's own PID appears in its own match list. So the fallback launch could never run, from `postStartCommand` or `relaunchSurface()`, and the exec still exited 0 so nothing was logged. It is masked by the code-server feature's own entrypoint — meaning there is no recovery at all if that entrypoint ever fails. Bracketing can't escape it here (unlike `claude-code-ide-extension`) because the payload text itself matches, so it now checks the port instead. ttyd keeps `pgrep -x`; process-name matching is correct there.

## Verification

`bun run checks` clean (315 tests). New tests confirmed to fail against the old code.

Live, against the stranded instance:

- Rebuild moved it off the poisoned port: `⚠ Host port 8021 is held by another process and isn't reachable — moving to 8023`
- New port answers `302`; the proxy returns `302` instead of the 503
- Regression: rebuilding a *healthy* instance kept its port (8019) and stayed reachable
- New guard verified both ways in-container — skips when 8080 is up, fires against a dead port — with no stacked duplicate daemon

## Notes

Two theories were ruled out with live evidence and deliberately left alone: code-server serving `/home/vscode` is harmless because `ideUrl` appends `?folder=`, and the `code-server-settings.json` copy does land (workspace trust is disabled there, not via the CLI flag).