### PR TITLE
feat: default Claude Code effort level setting

### DIFF
--- a/src/components/SettingsView.svelte
+++ b/src/components/SettingsView.svelte
@@ -33,12 +33,15 @@
 	import { avatars, findAvatar, type AvatarArt } from '../avatars/index.ts';
 	import {
 		CLAUDE_PERMISSION_MODES,
+		CLAUDE_EFFORT_LEVELS,
 		type ClaudePermissionMode,
+		type ClaudeEffortLevel,
 		type InstanceMode
 	} from '../types.ts';
 	import Terminal from '@lucide/svelte/icons/terminal';
 	import LayoutTemplate from '@lucide/svelte/icons/layout-template';
 	import ShieldCheck from '@lucide/svelte/icons/shield-check';
+	import Gauge from '@lucide/svelte/icons/gauge';
 	import { installPopupBackTrap } from '../lib/popup-nav.ts';
 
 	/** Every settings form action fails with the same `{ error }` shape. */
@@ -48,6 +51,7 @@
 		pet,
 		defaultMode,
 		claudePermissionMode,
+		claudeEffortLevel,
 		defaultImage,
 		builtinImage,
 		disableBuildCache,
@@ -85,6 +89,7 @@
 		pet?: AvatarArt;
 		defaultMode: InstanceMode;
 		claudePermissionMode: ClaudePermissionMode;
+		claudeEffortLevel: ClaudeEffortLevel;
 		defaultImage: string;
 		builtinImage: string;
 		disableBuildCache: boolean;
@@ -243,6 +248,35 @@
 		if (next === permissionChoice) return;
 		flushSync(() => (permissionChoice = next));
 		permissionFormEl?.requestSubmit();
+	}
+
+	// svelte-ignore state_referenced_locally
+	let effortChoice = $state<ClaudeEffortLevel>(claudeEffortLevel);
+	let savingEffort = $state(false);
+	let effortError = $state<string | null>(null);
+	let effortFormEl: HTMLFormElement | undefined;
+
+	const effortLevelOpts = saveOpts<{ level: ClaudeEffortLevel }>({
+		setSaving: (v) => (savingEffort = v),
+		setError: (v) => (effortError = v),
+		setMsg: () => {},
+		onSuccess: (data) => {
+			if (data?.level) effortChoice = data.level;
+		}
+	});
+
+	const EFFORT_LABELS: Record<ClaudeEffortLevel, string> = {
+		low: 'Low',
+		medium: 'Medium',
+		high: 'High',
+		xhigh: 'X-High',
+		max: 'Max'
+	};
+
+	function chooseEffort(next: ClaudeEffortLevel) {
+		if (next === effortChoice) return;
+		flushSync(() => (effortChoice = next));
+		effortFormEl?.requestSubmit();
 	}
 
 	// svelte-ignore state_referenced_locally
@@ -809,6 +843,46 @@
 			</form>
 			{#if permissionError}
 				<div class="sub"><div class="msg error">{permissionError}</div></div>
+			{/if}
+		</section>
+
+		<section class="card">
+			<form
+				class="row"
+				method="POST"
+				action="?/claudeEffortLevel"
+				bind:this={effortFormEl}
+				{@attach enhance(effortLevelOpts)}
+			>
+				<div class="label">
+					<Gauge size={20} />
+					<div class="text">
+						<div class="name">Claude effort level</div>
+						<div class="desc">
+							The default reasoning effort Claude Code starts new sessions at inside instances,
+							written to <code>~/.claude/settings.json</code>. Applies on create and rebuild, not to
+							already-running instances.
+						</div>
+					</div>
+				</div>
+				<input type="hidden" name="level" value={effortChoice} />
+				<div class="mode-toggle" role="group" aria-label="Claude effort level">
+					{#each CLAUDE_EFFORT_LEVELS as option (option)}
+						<button
+							type="button"
+							class="mode-btn"
+							class:active={effortChoice === option}
+							aria-pressed={effortChoice === option}
+							disabled={savingEffort}
+							onclick={() => chooseEffort(option)}
+						>
+							{EFFORT_LABELS[option]}
+						</button>
+					{/each}
+				</div>
+			</form>
+			{#if effortError}
+				<div class="sub"><div class="msg error">{effortError}</div></div>
 			{/if}
 		</section>
 

--- a/src/container-injections/claude-effort-level.ts
+++ b/src/container-injections/claude-effort-level.ts
@@ -1,0 +1,32 @@
+import { getOption } from '../lib/db.server.ts';
+import { mergeClaudeSettings, readClaudeSettings } from '../lib/claude-settings.server.ts';
+import { normalizeEffortLevel } from '../types.ts';
+import type { ClaudeEffortLevel } from '../types.ts';
+import type { Injection } from '../lib/injections.server.ts';
+
+/** Also read by the settings-page `serverProps` to seed the UI. */
+export function getClaudeEffortLevel(): ClaudeEffortLevel {
+	return normalizeEffortLevel(getOption('claude_effort_level'));
+}
+
+/** Writes Claude Code's `effortLevel` default into the container so new sessions start at the chosen effort. */
+export const claudeEffortLevel: Injection = {
+	id: 'claude-effort-level',
+	label: 'effort level',
+
+	async apply(target, log) {
+		const level = getClaudeEffortLevel();
+		log(`Setting Claude effort level (${level})…\n`);
+		const result = await mergeClaudeSettings(target, { effortLevel: level });
+		log(
+			result.ok
+				? '✓ Claude effort level configured in container\n'
+				: `⚠ Claude effort level injection failed: ${result.error}\n`
+		);
+	},
+
+	async check(target) {
+		const settings = await readClaudeSettings(target);
+		return settings?.effortLevel === getClaudeEffortLevel();
+	}
+};

--- a/src/container-injections/injections.isolated.test.ts
+++ b/src/container-injections/injections.isolated.test.ts
@@ -108,6 +108,14 @@ describe('injection registry', () => {
 		expect(typeof model!.check).toBe('function');
 	});
 
+	test('claude-effort-level is registered with a health check and no auth chip', () => {
+		const effort = injections.find((i) => i.id === 'claude-effort-level');
+		expect(effort).toBeDefined();
+		// Writes a settings.json default from the app option; no host dependency, so no chip.
+		expect(effort!.auth).toBeUndefined();
+		expect(typeof effort!.check).toBe('function');
+	});
+
 	test('host-env-vars is registered with a health check and no auth chip', () => {
 		const hostEnvVars = injections.find((i) => i.id === 'host-env-vars');
 		expect(hostEnvVars).toBeDefined();
@@ -171,6 +179,7 @@ describe('resolveInjectionStages — clobber safety', () => {
 		'claude-code-ide-extension': ['extensions-dir'],
 		'git-identity': ['gitconfig'],
 		'github-credentials': ['gh-hosts', 'gitconfig'],
+		'claude-effort-level': ['settings-json'],
 		'attention-hooks': ['bridge-header', 'settings-json'],
 		'claude-statusline': ['statusline-script', 'settings-json'],
 		'claude-code-models': ['models-env-file', 'rc'],
@@ -219,6 +228,7 @@ describe('resolveInjectionStages — clobber safety', () => {
 		expect(at.get('git-safe-directory')!).toBeLessThan(at.get('git-identity')!);
 		expect(at.get('git-identity')!).toBeLessThan(at.get('github-credentials')!);
 		// ~/.claude/settings.json merge chain.
+		expect(at.get('claude-effort-level')!).toBeLessThan(at.get('attention-hooks')!);
 		expect(at.get('attention-hooks')!).toBeLessThan(at.get('claude-statusline')!);
 		expect(at.get('claude-statusline')!).toBeLessThan(at.get('claude-model')!);
 		expect(at.get('claude-model')!).toBeLessThan(at.get('claude-trust')!);

--- a/src/lib/injections.server.ts
+++ b/src/lib/injections.server.ts
@@ -15,6 +15,7 @@ import { githubCredentials } from '../container-injections/github-credentials.ts
 import { attentionHooks } from '../container-injections/attention-hooks.ts';
 import { claudeStatusline } from '../container-injections/claude-statusline.ts';
 import { claudeModel } from '../container-injections/claude-model.ts';
+import { claudeEffortLevel } from '../container-injections/claude-effort-level.ts';
 import { claudePermissionMode } from '../container-injections/claude-permission-mode.ts';
 import { claudeTrust } from '../container-injections/claude-trust.ts';
 import { claudeAliases } from '../container-injections/claude-aliases.ts';
@@ -58,7 +59,14 @@ function buildStages(claudeInjection: Injection): Injection[][] {
 		// Open VSX extension) start immediately instead of queueing behind one another.
 		// claude-code-install (terminal-only) must precede claude-code-update: both are the sole
 		// npm-global writer of their stage, and the update no-ops until a binary exists.
-		[gitSafeDirectory, tmux, claudeCodeInstall, claudeInjection, claudeCodeIdeExtension],
+		[
+			gitSafeDirectory,
+			tmux,
+			claudeCodeInstall,
+			claudeInjection,
+			claudeCodeIdeExtension,
+			claudeEffortLevel
+		],
 		// git-identity needs stage 1's safe.directory; ttyd shares the apt/dpkg lock with tmux and
 		// the /usr/local/bin symlink with claude-code-install, so it trails both.
 		[gitIdentity, attentionHooks, claudeCodeModels, ttyd, claudeCodeUpdate],

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -3,12 +3,13 @@
 	import '@fontsource-variable/jetbrains-mono';
 	import SettingsView from '../components/SettingsView.svelte';
 	import type { AvatarArt } from '../avatars/index.ts';
-	import type { ClaudePermissionMode, InstanceMode } from '../types.ts';
+	import type { ClaudeEffortLevel, ClaudePermissionMode, InstanceMode } from '../types.ts';
 
 	let {
 		pet,
 		defaultMode,
 		claudePermissionMode,
+		claudeEffortLevel,
 		defaultImage,
 		builtinImage,
 		disableBuildCache,
@@ -46,6 +47,7 @@
 		pet?: AvatarArt;
 		defaultMode: InstanceMode;
 		claudePermissionMode: ClaudePermissionMode;
+		claudeEffortLevel: ClaudeEffortLevel;
 		defaultImage: string;
 		builtinImage: string;
 		disableBuildCache: boolean;
@@ -86,6 +88,7 @@
 	{pet}
 	{defaultMode}
 	{claudePermissionMode}
+	{claudeEffortLevel}
 	{defaultImage}
 	{builtinImage}
 	{disableBuildCache}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -25,6 +25,7 @@ import {
 	LATEST_VERSION_KEY
 } from './container-injections/claude-code-update.ts';
 import { getClaudePermissionMode } from './container-injections/claude-permission-mode.ts';
+import { getClaudeEffortLevel } from './container-injections/claude-effort-level.ts';
 import { browse } from './lib/picker.server.ts';
 import { pickNamePrompt } from './avatars/name-prompts.ts';
 import { avatars, findAvatar } from './avatars/index.ts';
@@ -67,6 +68,7 @@ import {
 	isInstanceFilter,
 	normalizeMode,
 	normalizePermissionMode,
+	normalizeEffortLevel,
 	type InstanceFilter
 } from './types.ts';
 
@@ -198,6 +200,7 @@ export const routes: Record<string, MochiRouteValue> = {
 				pet: currentPet(),
 				defaultMode: getDefaultMode(),
 				claudePermissionMode: getClaudePermissionMode(),
+				claudeEffortLevel: getClaudeEffortLevel(),
 				defaultImage: getOption('default_image') ?? DEFAULT_IMAGE,
 				builtinImage: DEFAULT_IMAGE,
 				disableBuildCache: getOption('disable_build_cache') === '1',
@@ -258,6 +261,13 @@ export const routes: Record<string, MochiRouteValue> = {
 				const mode = normalizePermissionMode(str(formData, 'mode'));
 				setOption('claude_permission_mode', mode);
 				return success({ mode });
+			},
+
+			// Injected into ~/.claude/settings.json at provision time, so it lands on create/rebuild.
+			claudeEffortLevel: ({ formData }) => {
+				const level = normalizeEffortLevel(str(formData, 'level'));
+				setOption('claude_effort_level', level);
+				return success({ level });
 			},
 
 			// Persist the default container image used when a source folder ships no devcontainer.json.

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'bun:test';
-import { claudePermissionFlags, isInstanceFilter, normalizePermissionMode } from './types.ts';
+import {
+	claudePermissionFlags,
+	isInstanceFilter,
+	normalizeEffortLevel,
+	normalizePermissionMode
+} from './types.ts';
 
 describe('isInstanceFilter', () => {
 	test('accepts the three valid tokens', () => {
@@ -25,6 +30,20 @@ describe('normalizePermissionMode', () => {
 	test('falls back to the historical bypass behaviour', () => {
 		for (const v of ['', 'PLAN', 'bypassPermissions', null, undefined, 0, {}]) {
 			expect(normalizePermissionMode(v)).toBe('default');
+		}
+	});
+});
+
+describe('normalizeEffortLevel', () => {
+	test('keeps the five supported levels', () => {
+		for (const level of ['low', 'medium', 'high', 'xhigh', 'max'] as const) {
+			expect(normalizeEffortLevel(level)).toBe(level);
+		}
+	});
+
+	test('falls back to high for anything unrecognised', () => {
+		for (const v of ['', 'HIGH', 'ultra', null, undefined, 0, {}]) {
+			expect(normalizeEffortLevel(v)).toBe('high');
 		}
 	});
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,18 @@ export function claudePermissionFlags(mode: ClaudePermissionMode): string {
 	return mode === 'default' ? '--dangerously-skip-permissions' : `--permission-mode ${mode}`;
 }
 
+/** Claude Code's default reasoning-effort level for new sessions, written to `settings.json`. */
+export type ClaudeEffortLevel = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+
+export const CLAUDE_EFFORT_LEVELS: ClaudeEffortLevel[] = ['low', 'medium', 'high', 'xhigh', 'max'];
+
+/** Anything unrecognised falls back to the balanced default. */
+export function normalizeEffortLevel(value: unknown): ClaudeEffortLevel {
+	return CLAUDE_EFFORT_LEVELS.includes(value as ClaudeEffortLevel)
+		? (value as ClaudeEffortLevel)
+		: 'high';
+}
+
 /** Dashboard run-state view filter: All | Active (running/creating) | Stopped (stopped/error). */
 export type InstanceFilter = 'all' | 'active' | 'stopped';
 


### PR DESCRIPTION
## What

Adds a **Claude effort level** control to the `/settings` page — one of `low | medium | high | xhigh | max`, defaulting to **high** — that is injected into every instance so new Claude Code sessions inside the container start at the chosen reasoning effort.

## How

Claude Code reads its persistent per-session effort default from the `"effortLevel"` field of `~/.claude/settings.json` (exactly what the `/effort` command writes). So this ships as a new **`claude-effort-level` container injection** that deep-merges `{ effortLevel }` into that file — a near-verbatim clone of the existing `claude-model` injection. Chosen over the permission-mode-style CLI-flag/alias approach because it:

- is the genuine persistent default for *all* new sessions in the container (auto-launched, manually typed `claude`, subagents);
- needs **no** changes to the launchers / `writeOverrideConfig` and no shell alias (which would collide with the one `claude-permission-mode` owns);
- composes cleanly with the other `settings.json` writers via the existing `mergeClaudeSettings` deep-merge.

Like the permission-mode setting, it applies on create/rebuild, not to already-running instances.

## Changes

- `src/types.ts` — `ClaudeEffortLevel` type, `CLAUDE_EFFORT_LEVELS`, `normalizeEffortLevel()` (defaults to `high`).
- `src/container-injections/claude-effort-level.ts` — new injection (`apply` merges `effortLevel`, `check` reads it back) + `getClaudeEffortLevel()` reader for the option `claude_effort_level`.
- `src/lib/injections.server.ts` — registered in stage 1, the only boot stage without another `settings.json` writer (keeps the one-writer-per-stage no-clobber invariant intact).
- `src/routes.ts` — `serverProps` seed + `claudeEffortLevel` form action.
- `src/pages/Settings.svelte` / `src/components/SettingsView.svelte` — a segmented toggle control matching the existing permission-mode UI.
- Tests — `normalizeEffortLevel` cases; injection registration + the stage no-clobber/ordering map extended for the new injection.

## Verification

- `bun run checks` — format + eslint + typecheck (0 errors) + 318 tests pass.
- SSR smoke test of `/settings`: the control renders with **High** active by default (hidden `level=high`) and all five buttons present.
- Live in-container verification (`cat ~/.claude/settings.json` shows the chosen `effortLevel`) was **not** run — no Docker daemon available in this environment. Worth a manual check on a machine with Docker.