### PR TITLE
fix: keep the boot-log Follow toggle from turning itself off

### DIFF
--- a/src/components/InstanceView.svelte
+++ b/src/components/InstanceView.svelte
@@ -22,26 +22,24 @@
 	let logEl = $state<HTMLDivElement | null>(null);
 	let following = $state(true);
 
-	// Pin to the newest output whenever logs grow — but only while following.
-	// tick() lets the <pre> text node grow before we scroll, so we reach the true bottom.
-	$effect(() => {
-		if (!following || logs.length === 0) return; // reading logs.length tracks appended chunks
-		tick().then(() => {
-			if (following) logEl?.scrollTo(0, logEl.scrollHeight);
-		});
-	});
-
-	// A user scrolling up pauses following; programmatic scroll-to-bottom keeps the
-	// gap ~0, so it never trips this — only re-clicking "Follow log" resumes.
-	function onLogScroll() {
-		if (!logEl) return;
-		const gap = logEl.scrollHeight - logEl.clientHeight - logEl.scrollTop;
-		if (gap > 40) following = false;
+	// tick() lets the <pre> text node grow before we measure, so we reach the true bottom.
+	async function scrollToBottom() {
+		await tick();
+		logEl?.scrollTo(0, logEl.scrollHeight);
 	}
 
+	// Pin to the newest output whenever logs grow — but only while following.
+	$effect(() => {
+		if (!following || logs.length === 0) return; // reading logs.length tracks appended chunks
+		scrollToBottom();
+	});
+
+	// Following is deliberately sticky: only this button changes it. Inferring it from
+	// scroll events misfired constantly, since streaming chunks and reflow above the log
+	// both move scrollTop without the user touching anything.
 	function toggleFollow() {
 		following = !following;
-		if (following) logEl?.scrollTo(0, logEl.scrollHeight);
+		if (following) scrollToBottom();
 	}
 
 	$effect(() => installPopupBackTrap());
@@ -255,7 +253,14 @@
 		<div class="log-bar panel-bar">
 			<span>Boot log</span>
 			<div class="log-actions">
-				<button class="copy" class:active={following} onclick={toggleFollow}>
+				<button
+					class="copy"
+					class:active={following}
+					aria-pressed={following}
+					title={following ? 'Following — click to pause' : 'Paused — click to follow new output'}
+					onclick={toggleFollow}
+				>
+					{#if following}<span class="dot"></span>{/if}
 					{following ? 'Following' : 'Follow log'}
 				</button>
 				<button class="copy" onclick={copyLogs} disabled={!logs}>
@@ -263,7 +268,7 @@
 				</button>
 			</div>
 		</div>
-		<div class="logs" bind:this={logEl} onscroll={onLogScroll}>
+		<div class="logs" bind:this={logEl}>
 			<pre>{logs || 'Waiting for output…'}<span class="caret"></span></pre>
 		</div>
 		{#if instance?.status === 'error' && instance.error}
@@ -535,6 +540,9 @@
 		align-items: center;
 	}
 	.copy {
+		display: inline-flex;
+		align-items: center;
+		gap: 5px;
 		font-family: var(--font-mono);
 		font-weight: 600;
 		font-size: 10px;
@@ -554,6 +562,14 @@
 		background: transparent;
 		color: var(--bg);
 	}
+	/* The dot, not the inverted fill, is what separates "following" from a mere hover. */
+	.dot {
+		flex: none;
+		width: 6px;
+		height: 6px;
+		border-radius: 50%;
+		background: var(--attn-done);
+	}
 	.copy:disabled {
 		opacity: 0.5;
 		cursor: not-allowed;
@@ -568,6 +584,8 @@
 		height: calc(100vh - 320px);
 		min-height: 360px;
 		overflow: auto;
+		/* Scroll anchoring would shift scrollTop as the <pre> grows; a paused log must stay put. */
+		overflow-anchor: none;
 	}
 	.logs pre {
 		margin: 0;


### PR DESCRIPTION
## The bug

The **Follow log / Following** toggle on the instance page turns itself off on its own — including when the pointer is nowhere near the log box — so streaming output silently stops pinning to the bottom.

`onLogScroll` treated *any* `scroll` event on `.logs` as "the user scrolled up":

```js
const gap = logEl.scrollHeight - logEl.clientHeight - logEl.scrollTop;
if (gap > 40) following = false;
```

Two ways that fires with no user input:

1. **The auto-scroll racing its own event.** The pin ran as `tick().then(() => logEl.scrollTo(0, logEl.scrollHeight))`, and the resulting `scroll` event is dispatched asynchronously. If another chunk lands in between, the handler measures the *already-grown* `scrollHeight`, sees `gap > 40`, and unfollows. Heavy `devcontainer up` output — exactly when Follow matters — is the reliable repro.
2. **Reflow above the log.** `.logs` is `height: calc(100vh - 320px)`, and the health rows, ports box, and error banners above it grow and shrink as central-stream data arrives. Each height change clamps `scrollTop` and fires a `scroll` event with a stale gap. This is the "I wasn't even touching it" case.

## The fix

Follow becomes a **sticky mode changed only by the button** — no scroll-derived state at all, so there is nothing left to misfire. Scrolling up while following is on no longer unlocks it; you click **Following** to pause first.

Also in this change:

- Fold the two divergent scroll-to-bottom call sites into one `tick()`-awaiting `scrollToBottom()`. `toggleFollow` previously scrolled *without* `tick()`, so re-enabling Follow mid-chunk landed short of the bottom.
- `overflow-anchor: none` on `.logs` — scroll anchoring can shift `scrollTop` as the `<pre>` grows, and a paused log must stay exactly where it was left.
- Give the on-state a real affordance: a dot before the label plus `aria-pressed`. `.copy.active` was byte-identical to `.copy:hover`, so "Following" looked the same as merely hovering "Follow log" — part of why the silent flip went unnoticed.

One file, `src/components/InstanceView.svelte`. No server, route, or `live.ts` changes.

## Verification

`bun run checks` passes clean (315 tests, 0 svelte-check errors; the 4 warnings are pre-existing in `AppShell`/`AvatarEditor`).

No Docker daemon was available in the dev container, so the streaming-boot-log behavior was **not** exercised live. What was checked: the dev server boots, an instance page renders, and the compiled hydration bundle carries the new `aria-pressed`/`title` markup with zero remaining references to the deleted scroll handler. Worth a manual pass on a real boot before merge:

- Log stays pinned for a whole noisy boot and the button never flips on its own.
- Clicking **Following** pauses and the view stays put while output keeps arriving.
- Clicking **Follow log** jumps to the true bottom, even mid-chunk.
- Adding/removing a port forward (reflow above the log) while following doesn't disturb it.