### PR TITLE
feat: redesign the IDE instance tabs

### DIFF
--- a/src/components/AppShell.svelte
+++ b/src/components/AppShell.svelte
@@ -303,7 +303,12 @@
 	<div class="panes" class:hidden={!onIde}>
 		{#each running as inst (inst.id)}
 			{#if visited.has(inst.id)}
-				<div class="pane" class:active={inst.id === active}>
+				<div
+					class="pane"
+					class:active={inst.id === active}
+					role="tabpanel"
+					aria-labelledby="tab-{inst.id}"
+				>
 					{#if mountable(inst.id)}
 						{#if inst.mode === 'terminal'}
 							<TerminalSplit

--- a/src/components/AppShell.svelte
+++ b/src/components/AppShell.svelte
@@ -44,6 +44,8 @@
 	let loaded = $state(snapshot.length > 0);
 	const running = $derived(instances.filter((i) => i.status === 'running'));
 
+	// Seeded from the SSR snapshot like `instances` above — the live stream overwrites it.
+	// svelte-ignore state_referenced_locally
 	let attention = $state<Record<string, 'done' | 'waiting' | null>>(
 		Object.fromEntries(snapshot.map((i) => [i.id, i.attention]))
 	);

--- a/src/components/AppShell.svelte
+++ b/src/components/AppShell.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import { ideUrl, type Instance, type InstanceFilter, type Preflight } from '../types.ts';
 	import { findAvatar, type AvatarArt } from '../avatars/index.ts';
+	import { tick } from 'svelte';
 	import { SvelteSet } from 'svelte/reactivity';
+	import { nextTabIndex } from '../lib/tab-nav.ts';
 	import DashboardView from './DashboardView.svelte';
 	import IdeBar from './IdeBar.svelte';
 	import IdeLoader from './IdeLoader.svelte';
@@ -177,6 +179,60 @@
 
 	$effect(() => {
 		document.title = onIde && activeInstance ? `${activeInstance.name} — Codebay` : 'Codebay';
+	});
+
+	// Alt+1-9 switches tabs. Alt, specifically: Cmd/Ctrl+digit is reserved by the browser
+	// for its own tabs and can't be intercepted, and Ctrl+Alt is AltGr on many European
+	// layouts, so it would collide with typing punctuation.
+	function jumpToTab(e: KeyboardEvent, fromFrame: boolean) {
+		if (!e.altKey || e.ctrlKey || e.metaKey || editingId) return;
+		// `code`, not `key`: Alt+digit emits punctuation on macOS layouts.
+		const digit = /^Digit([1-9])$/.exec(e.code)?.[1];
+		if (!digit) return;
+		const next = nextTabIndex(
+			running.findIndex((i) => i.id === active),
+			digit,
+			running.length
+		);
+		const target = next === null ? undefined : running[next];
+		if (!target) return;
+		e.preventDefault();
+		// Stops the editor acting on the same keystroke as well.
+		e.stopPropagation();
+		navigate(`/ide/${target.id}`);
+		// Came from inside an editor, so land inside the next one rather than dumping
+		// focus on the body — after a tick, once the destination pane is no longer hidden.
+		if (fromFrame) void tick().then(() => frames[target.id]?.contentWindow?.focus());
+	}
+
+	// Joined rather than an array so the value compares equal across reconcile ticks —
+	// otherwise the effect below would tear down and re-add every listener every few
+	// seconds, with a window each time where a keystroke lands on nothing.
+	const framedTabIds = $derived(
+		running
+			.filter((i) => i.mode !== 'terminal' && loadedFrames.has(i.id))
+			.map((i) => i.id)
+			.join(' ')
+	);
+
+	// A focused iframe never bubbles keydown to the parent, so the shortcut has to be
+	// installed inside each editor document as well — possible only because the proxy
+	// serves code-server same-origin under /p/:id/. Capture phase, so it lands before
+	// VS Code's own handlers (and before xterm.js in the terminal panes).
+	$effect(() => {
+		if (!onIde) return;
+		function listen(target: Window, fromFrame: boolean) {
+			const handler = (e: KeyboardEvent) => jumpToTab(e, fromFrame);
+			target.addEventListener('keydown', handler, { capture: true });
+			return () => target.removeEventListener('keydown', handler, { capture: true });
+		}
+		const detach = [listen(window, false)];
+		// A reloaded iframe gets a fresh Window, and the old listener dies with it.
+		for (const id of framedTabIds.split(' ').filter(Boolean)) {
+			const frameWindow = frames[id]?.contentWindow;
+			if (frameWindow) detach.push(listen(frameWindow, true));
+		}
+		return () => detach.forEach((off) => off());
 	});
 
 	// Browsers block audio until the page has been interacted with.

--- a/src/components/IdeBar.svelte
+++ b/src/components/IdeBar.svelte
@@ -5,9 +5,12 @@
 	import RotateCw from '@lucide/svelte/icons/rotate-cw';
 	import Terminal from '@lucide/svelte/icons/terminal';
 	import LayoutTemplate from '@lucide/svelte/icons/layout-template';
+	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
+	import ChevronRight from '@lucide/svelte/icons/chevron-right';
 	import Avatar from './Avatar.svelte';
 	import AppBar from './AppBar.svelte';
 	import { withPopupMarker } from '../lib/popup-nav.ts';
+	import { nextTabIndex } from '../lib/tab-nav.ts';
 
 	let {
 		running,
@@ -33,62 +36,181 @@
 		oncommitrename: (id: string) => void;
 		oncancelrename: () => void;
 	} = $props();
+
+	const activeIndex = $derived(running.findIndex((i) => i.id === active));
+	// Falls back to the first tab so the strip always offers exactly one tab stop,
+	// even when `active` names an instance that has since stopped.
+	const focusIndex = $derived(activeIndex >= 0 ? activeIndex : 0);
+
+	let viewport = $state<HTMLDivElement | null>(null);
+	let content = $state<HTMLDivElement | null>(null);
+	let atStart = $state(true);
+	let atEnd = $state(true);
+	// `$state` rather than a plain object so `bind:this` into it is a tracked write —
+	// otherwise Svelte warns, and the scroll-into-view effect below misses the first bind.
+	const tabEls = $state<Record<string, HTMLButtonElement | null>>({});
+
+	// Both true means everything fits, so the chevrons stay out of a bar that only has 44px.
+	const overflowing = $derived(!atStart || !atEnd);
+
+	// 1px of slack: fractional layout widths leave scrollLeft a hair short of the true end.
+	function measure() {
+		if (!viewport) return;
+		atStart = viewport.scrollLeft <= 1;
+		atEnd = viewport.scrollLeft + viewport.clientWidth >= viewport.scrollWidth - 1;
+	}
+
+	function select(index: number) {
+		const inst = running[index];
+		if (!inst) return;
+		onselect(inst.id);
+		tabEls[inst.id]?.focus();
+	}
+
+	function onTabKeydown(e: KeyboardEvent) {
+		const next = nextTabIndex(activeIndex, e.key, running.length);
+		if (next === null) return;
+		e.preventDefault();
+		select(next);
+	}
+
+	function page(direction: -1 | 1) {
+		if (!viewport) return;
+		viewport.scrollBy({ left: direction * Math.max(160, viewport.clientWidth * 0.7) });
+	}
+
+	// Observing the content too, not just the viewport — adding or removing a tab moves
+	// scrollWidth without ever resizing the scroll container.
+	$effect(() => {
+		const vp = viewport;
+		const ct = content;
+		if (!vp || !ct) return;
+		measure();
+		const ro = new ResizeObserver(measure);
+		ro.observe(vp);
+		ro.observe(ct);
+		vp.addEventListener('scroll', measure, { passive: true });
+		return () => {
+			ro.disconnect();
+			vp.removeEventListener('scroll', measure);
+		};
+	});
+
+	// Keyboard selection can land on a tab that's scrolled out of sight.
+	$effect(() => {
+		tabEls[active]?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+	});
+
+	// Only fires while the shell chrome has focus — a focused code-server iframe
+	// swallows keydown before it ever reaches this document.
+	$effect(() => {
+		function onKeydown(e: KeyboardEvent) {
+			if (!e.altKey || e.ctrlKey || e.metaKey || editingId) return;
+			// `code`, not `key`: Alt+digit emits punctuation on macOS layouts.
+			const digit = /^Digit([1-9])$/.exec(e.code)?.[1];
+			if (!digit) return;
+			const next = nextTabIndex(activeIndex, digit, running.length);
+			if (next === null) return;
+			e.preventDefault();
+			select(next);
+		}
+		window.addEventListener('keydown', onKeydown);
+		return () => window.removeEventListener('keydown', onKeydown);
+	});
 </script>
 
 <AppBar>
 	{#if running.length > 0}
-		<nav class="tabs">
-			{#each running as inst (inst.id)}
-				<div
-					class="tab"
-					class:active={inst.id === active}
-					class:attn-done={inst.id !== active && attention[inst.id] === 'done'}
-					class:attn-waiting={inst.id !== active && attention[inst.id] === 'waiting'}
+		<div class="strip">
+			{#if overflowing}
+				<button
+					type="button"
+					class="page"
+					disabled={atStart}
+					onclick={() => page(-1)}
+					aria-label="Scroll tabs left"><ChevronLeft size={16} /></button
 				>
-					{#if editingId === inst.id}
-						<div class="tab-label editing">
-							<Avatar
-								name={inst.name}
-								art={findAvatar(inst.avatar ?? undefined) ?? null}
-								scale={4}
-							/>
-							<!-- svelte-ignore a11y_autofocus -->
-							<input
-								class="tab-name-edit"
-								bind:value={editingName}
-								autofocus
-								onfocus={(e) => (e.currentTarget as HTMLInputElement).select()}
-								onblur={() => oncommitrename(inst.id)}
-								onkeydown={(e) => {
-									if (e.key === 'Enter') (e.currentTarget as HTMLInputElement).blur();
-									else if (e.key === 'Escape') oncancelrename();
-								}}
-							/>
-						</div>
-					{:else}
-						<button
-							type="button"
-							class="tab-label"
-							onclick={() => onselect(inst.id)}
-							ondblclick={() => onstartrename(inst)}
-							title={inst.name}
-						>
-							<Avatar
-								name={inst.name}
-								art={findAvatar(inst.avatar ?? undefined) ?? null}
-								scale={4}
-							/>
-							<span class="tab-name">{inst.name}</span>
-							{#if inst.mode === 'terminal'}
-								<span class="tab-mode" title="Terminal-only instance"><Terminal size={13} /></span>
-							{:else}
-								<span class="tab-mode" title="Full IDE instance"><LayoutTemplate size={13} /></span>
-							{/if}
-						</button>
-					{/if}
+			{/if}
+			<div class="viewport" bind:this={viewport}>
+				<div class="tabs" role="tablist" aria-label="Instances" bind:this={content}>
+					{#each running as inst, i (inst.id)}
+						{#if editingId === inst.id}
+							<div class="tab editing">
+								<Avatar
+									name={inst.name}
+									art={findAvatar(inst.avatar ?? undefined) ?? null}
+									scale={3}
+								/>
+								<!-- svelte-ignore a11y_autofocus -->
+								<input
+									class="tab-name-edit"
+									bind:value={editingName}
+									autofocus
+									onfocus={(e) => (e.currentTarget as HTMLInputElement).select()}
+									onblur={() => oncommitrename(inst.id)}
+									onkeydown={(e) => {
+										if (e.key === 'Enter') (e.currentTarget as HTMLInputElement).blur();
+										else if (e.key === 'Escape') oncancelrename();
+									}}
+								/>
+							</div>
+						{:else}
+							<button
+								bind:this={tabEls[inst.id]}
+								type="button"
+								class="tab"
+								class:active={inst.id === active}
+								id="tab-{inst.id}"
+								role="tab"
+								aria-selected={inst.id === active}
+								tabindex={i === focusIndex ? 0 : -1}
+								onclick={() => onselect(inst.id)}
+								ondblclick={() => onstartrename(inst)}
+								onkeydown={onTabKeydown}
+								title={inst.name}
+							>
+								<Avatar
+									name={inst.name}
+									art={findAvatar(inst.avatar ?? undefined) ?? null}
+									scale={3}
+								/>
+								<span class="tab-name">{inst.name}</span>
+								<span
+									class="tab-mode"
+									aria-label={inst.mode === 'terminal'
+										? 'Terminal-only instance'
+										: 'Full IDE instance'}
+								>
+									{#if inst.mode === 'terminal'}
+										<Terminal size={11} />
+									{:else}
+										<LayoutTemplate size={11} />
+									{/if}
+								</span>
+								<!-- The focused tab never lights up, so a lit LED always means "needs your eyes". -->
+								{#if inst.id !== active && attention[inst.id]}
+									<span
+										class="attn {attention[inst.id]}"
+										aria-label={attention[inst.id] === 'waiting'
+											? 'Claude is waiting for input'
+											: 'Claude finished'}
+									></span>
+								{/if}
+							</button>
+						{/if}
+					{/each}
 				</div>
-			{/each}
-		</nav>
+			</div>
+			{#if overflowing}
+				<button
+					type="button"
+					class="page trailing"
+					disabled={atEnd}
+					onclick={() => page(1)}
+					aria-label="Scroll tabs right"><ChevronRight size={16} /></button
+				>
+			{/if}
+		</div>
 	{/if}
 	<div class="right">
 		{#if onreload}
@@ -142,74 +264,107 @@
 		background: var(--ink);
 		color: var(--bg);
 	}
+
+	.strip {
+		display: flex;
+		align-items: stretch;
+		min-width: 0;
+	}
+	/* The native scrollbar would eat into a 44px bar, so the chevrons replace it. */
+	.viewport {
+		display: flex;
+		min-width: 0;
+		overflow-x: auto;
+		scroll-behavior: smooth;
+		scrollbar-width: none;
+	}
+	.viewport::-webkit-scrollbar {
+		display: none;
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.viewport {
+			scroll-behavior: auto;
+		}
+	}
 	.tabs {
 		display: flex;
 		align-items: stretch;
-		overflow-x: auto;
-		min-width: 0;
+		flex: none;
 	}
-	.tab {
+
+	.page {
 		display: inline-flex;
-		align-items: stretch;
-		border-right: 1px solid var(--rule-soft);
-	}
-	.tab.active {
-		background: var(--ink);
-	}
-	/* The focused tab never gets these, so a pulsing tab always means "needs your eyes". */
-	.tab.attn-done {
-		animation: attn-pulse-green 1.8s ease-in-out infinite;
-	}
-	.tab.attn-waiting {
-		animation: attn-pulse-amber 1.8s ease-in-out infinite;
-	}
-	@keyframes attn-pulse-green {
-		0%,
-		100% {
-			background: transparent;
-			box-shadow: inset 0 -2px 0 color-mix(in srgb, var(--attn-done) 40%, transparent);
-		}
-		50% {
-			background: color-mix(in srgb, var(--attn-done) 32%, transparent);
-			box-shadow: inset 0 -2px 0 var(--attn-done);
-		}
-	}
-	@keyframes attn-pulse-amber {
-		0%,
-		100% {
-			background: transparent;
-			box-shadow: inset 0 -2px 0 color-mix(in srgb, var(--attn-waiting) 40%, transparent);
-		}
-		50% {
-			background: color-mix(in srgb, var(--attn-waiting) 32%, transparent);
-			box-shadow: inset 0 -2px 0 var(--attn-waiting);
-		}
-	}
-	@media (prefers-reduced-motion: reduce) {
-		.tab.attn-done,
-		.tab.attn-waiting {
-			animation-duration: 0s;
-			background: color-mix(in srgb, var(--attn-done) 28%, transparent);
-		}
-		.tab.attn-waiting {
-			background: color-mix(in srgb, var(--attn-waiting) 28%, transparent);
-		}
-	}
-	.tab-label {
+		align-items: center;
+		justify-content: center;
+		width: 28px;
+		flex: none;
 		appearance: none;
-		background: transparent;
+		margin: 0;
+		padding: 0;
 		border: 0;
+		border-right: 1px solid var(--rule);
+		background: var(--bg-card);
+		color: var(--ink);
 		cursor: pointer;
-		color: var(--ink-soft);
-		font-family: var(--font-mono);
+	}
+	.page.trailing {
+		border-right: 0;
+		border-left: 1px solid var(--rule);
+	}
+	.page:hover:not(:disabled) {
+		background: var(--ink);
+		color: var(--bg);
+	}
+	.page:disabled {
+		opacity: 0.4;
+		cursor: default;
+	}
+	.page:focus-visible {
+		outline: 2px solid var(--ink);
+		outline-offset: -2px;
+	}
+
+	.tab {
 		display: inline-flex;
 		align-items: center;
 		gap: 10px;
-		padding: 0 12px;
+		flex: none;
 		max-width: 240px;
-		font-size: 12px;
+		appearance: none;
+		margin: 0;
+		padding: 0 12px;
+		border: 0;
+		border-right: 1px solid var(--rule);
+		background: transparent;
+		color: var(--ink-soft);
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 13px;
 		text-transform: uppercase;
 		letter-spacing: 0.06em;
+		cursor: pointer;
+		/* Quantized like the instance cards — motion in this theme reads as digital. */
+		transition: background 0.08s steps(2);
+	}
+	/* Inversion is the house hover idiom, but it's also the active state here, so hovering
+	   gets a tint instead — that keeps idle → hover → active legible as three steps. */
+	.tab:not(.active):hover {
+		background: color-mix(in srgb, var(--ink) 12%, transparent);
+		color: var(--ink);
+	}
+	.tab.active {
+		background: var(--ink);
+		color: var(--bg);
+		cursor: default;
+		/* The key has sunk into the chassis; this strip is the slot it dropped out of. */
+		box-shadow: inset 0 3px 0 var(--bg);
+	}
+	.tab:focus-visible {
+		outline: 2px solid var(--ink);
+		outline-offset: -2px;
+	}
+	.tab.active:focus-visible {
+		outline-color: var(--bg);
 	}
 	.tab-name {
 		white-space: nowrap;
@@ -219,29 +374,65 @@
 	.tab-mode {
 		display: inline-flex;
 		align-items: center;
+		justify-content: center;
 		flex: none;
-		opacity: 0.75;
+		width: 18px;
+		height: 18px;
+		border: 1px solid currentColor;
+		opacity: 0.7;
 	}
-	.tab:not(.active) .tab-label:hover {
-		color: var(--ink);
+
+	.attn {
+		flex: none;
+		width: 10px;
+		height: 10px;
+		border: 1px solid var(--ink);
+		animation: tab-attn-pulse 1.4s ease-in-out infinite;
 	}
-	.tab.active .tab-label {
-		color: var(--bg);
+	.attn.done {
+		background: var(--attn-done);
+		color: var(--attn-done);
 	}
-	.tab-label.editing {
+	.attn.waiting {
+		background: var(--attn-waiting);
+		color: var(--attn-waiting);
+	}
+	/* Redeclared rather than shared with InstanceCard — Svelte scopes keyframes per component. */
+	@keyframes tab-attn-pulse {
+		0%,
+		100% {
+			box-shadow: 0 0 0 0 transparent;
+			filter: brightness(0.85);
+		}
+		50% {
+			box-shadow: 0 0 6px 2px color-mix(in srgb, currentColor 60%, transparent);
+			filter: brightness(1.15);
+		}
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.attn {
+			animation: none;
+			filter: none;
+		}
+	}
+
+	.tab.editing {
 		cursor: default;
 	}
 	.tab-name-edit {
-		width: 130px;
+		width: 148px;
 		font-family: var(--font-mono);
 		font-size: 12px;
 		text-transform: uppercase;
 		letter-spacing: 0.06em;
 		margin: 0;
-		padding: 2px 4px;
-		border: 1px solid var(--ink-soft);
+		padding: 3px 6px;
+		border: 1px solid var(--ink);
 		background: var(--bg);
 		color: var(--ink);
-		outline: none;
+	}
+	.tab-name-edit:focus-visible {
+		outline: 2px solid var(--ink);
+		outline-offset: -2px;
 	}
 </style>

--- a/src/components/IdeBar.svelte
+++ b/src/components/IdeBar.svelte
@@ -100,23 +100,6 @@
 	$effect(() => {
 		tabEls[active]?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
 	});
-
-	// Only fires while the shell chrome has focus — a focused code-server iframe
-	// swallows keydown before it ever reaches this document.
-	$effect(() => {
-		function onKeydown(e: KeyboardEvent) {
-			if (!e.altKey || e.ctrlKey || e.metaKey || editingId) return;
-			// `code`, not `key`: Alt+digit emits punctuation on macOS layouts.
-			const digit = /^Digit([1-9])$/.exec(e.code)?.[1];
-			if (!digit) return;
-			const next = nextTabIndex(activeIndex, digit, running.length);
-			if (next === null) return;
-			e.preventDefault();
-			select(next);
-		}
-		window.addEventListener('keydown', onKeydown);
-		return () => window.removeEventListener('keydown', onKeydown);
-	});
 </script>
 
 <AppBar>

--- a/src/components/UiShowcase.svelte
+++ b/src/components/UiShowcase.svelte
@@ -16,6 +16,7 @@
 	import BranchBox from './BranchBox.svelte';
 	import PortsBox from './PortsBox.svelte';
 	import StatusBadge from './StatusBadge.svelte';
+	import IdeBar from './IdeBar.svelte';
 	import ComponentDemo from './ui-showcase/ComponentDemo.svelte';
 	import type { Instance } from '../types.ts';
 
@@ -139,6 +140,68 @@
 
 	const statuses: Instance['status'][] = ['creating', 'running', 'stopped', 'error'];
 	let badgeStatus = $state<Instance['status']>('error');
+
+	// The IDE tab strip only ever renders against running instances, and this
+	// environment may have no Docker at all — so the demo fabricates them.
+	const TAB_NAMES = [
+		'orion',
+		'meridian',
+		'atlas',
+		'vesper',
+		'cobalt',
+		'juniper',
+		'halcyon',
+		'zenith',
+		'perigee',
+		'lumen'
+	];
+	let tabCount = $state(4);
+	let tabActive = $state(0);
+	let tabAttention = $state(true);
+	let tabMixModes = $state(true);
+	let tabLongNames = $state(false);
+	let tabEditingId = $state<string | null>(null);
+	let tabEditingName = $state('');
+	// Renames are applied for real, so the inline editor is inspectable end to end.
+	let tabRenames = $state<Record<string, string>>({});
+
+	const demoTabs = $derived(
+		Array.from({ length: tabCount }, (_, i): Instance => {
+			const id = `demo-tab-${i}`;
+			const base = TAB_NAMES[i]!;
+			return {
+				id,
+				name: tabRenames[id] ?? (tabLongNames ? `${base}-refactor-spike-2026` : base),
+				source_path: `/home/demo/${base}`,
+				workspace_path: `/data/instances/${id}`,
+				host_port: 8001 + i,
+				container_id: `container-${i}`,
+				remote_workspace_folder: null,
+				status: 'running',
+				error: null,
+				created_at: 0,
+				image_source: 'local',
+				avatar: avatars[i % avatars.length]!.name,
+				mode: tabMixModes && i % 2 === 1 ? 'terminal' : 'ide',
+				terminal_split: 0,
+				git_branch: 'main',
+				attention: null,
+				forwarded_ports: []
+			};
+		})
+	);
+	// Clamped, since dragging the count down can strand the active index past the end.
+	const demoActiveIndex = $derived(Math.min(tabActive, tabCount - 1));
+	const demoActiveId = $derived(demoTabs[demoActiveIndex]?.id ?? '');
+	// Alternating states so both LED colors are comparable side by side.
+	const demoAttention = $derived(
+		Object.fromEntries(
+			demoTabs.map((inst, i) => [
+				inst.id,
+				tabAttention && i !== demoActiveIndex ? (i % 2 === 0 ? 'done' : 'waiting') : null
+			])
+		) as Record<string, 'done' | 'waiting' | null>
+	);
 </script>
 
 <Toaster />
@@ -370,6 +433,56 @@
 			{/snippet}
 		</ComponentDemo>
 
+		<ComponentDemo title="IdeBar">
+			<div class="ide-bar-demo">
+				<IdeBar
+					running={demoTabs}
+					active={demoActiveId}
+					attention={demoAttention}
+					editingId={tabEditingId}
+					bind:editingName={tabEditingName}
+					onreload={() => toast('Reload editor (demo)')}
+					onselect={(id) => (tabActive = demoTabs.findIndex((t) => t.id === id))}
+					onstartrename={(inst) => {
+						tabEditingId = inst.id;
+						tabEditingName = inst.name;
+					}}
+					oncommitrename={(id) => {
+						const name = tabEditingName.trim();
+						if (name) tabRenames[id] = name;
+						tabEditingId = null;
+					}}
+					oncancelrename={() => (tabEditingId = null)}
+				/>
+			</div>
+			<p class="demo-hint">
+				Click to select, double-click to rename. Arrow keys / Home / End move between tabs once one
+				has focus; Alt+1–9 jumps directly (9 = last).
+			</p>
+			{#snippet controls()}
+				<label>
+					<span>tabs ({tabCount})</span>
+					<input type="range" min="1" max="10" bind:value={tabCount} />
+				</label>
+				<label>
+					<span>active ({demoActiveIndex})</span>
+					<input type="range" min="0" max={tabCount - 1} bind:value={tabActive} />
+				</label>
+				<label>
+					<span>attention</span>
+					<input type="checkbox" bind:checked={tabAttention} />
+				</label>
+				<label>
+					<span>mixed modes</span>
+					<input type="checkbox" bind:checked={tabMixModes} />
+				</label>
+				<label>
+					<span>long names</span>
+					<input type="checkbox" bind:checked={tabLongNames} />
+				</label>
+			{/snippet}
+		</ComponentDemo>
+
 		<ComponentDemo title="Brand" note="No props — static branding.">
 			<Brand />
 		</ComponentDemo>
@@ -465,6 +578,17 @@
 		flex-wrap: wrap;
 		align-items: center;
 		gap: 10px;
+	}
+	/* The bar spans the full IDE viewport in situ, so give it the whole stage here. */
+	.ide-bar-demo {
+		width: 100%;
+		border: 1px solid var(--rule-soft);
+	}
+	.demo-hint {
+		margin: 0;
+		font-family: var(--font-mono);
+		font-size: 11px;
+		color: var(--ink-faint);
 	}
 	.presets {
 		display: flex;

--- a/src/components/UiShowcase.svelte
+++ b/src/components/UiShowcase.svelte
@@ -457,7 +457,8 @@
 			</div>
 			<p class="demo-hint">
 				Click to select, double-click to rename. Arrow keys / Home / End move between tabs once one
-				has focus; Alt+1–9 jumps directly (9 = last).
+				has focus. The Alt+1–9 jump lives in AppShell rather than here, since it also installs
+				itself into the editor iframes — so it is inert in this demo.
 			</p>
 			{#snippet controls()}
 				<label>

--- a/src/lib/tab-nav.test.ts
+++ b/src/lib/tab-nav.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'bun:test';
+import { nextTabIndex } from './tab-nav.ts';
+
+describe('nextTabIndex', () => {
+	test('arrows wrap around both ends', () => {
+		expect(nextTabIndex(0, 'ArrowRight', 3)).toBe(1);
+		expect(nextTabIndex(2, 'ArrowRight', 3)).toBe(0);
+		expect(nextTabIndex(2, 'ArrowLeft', 3)).toBe(1);
+		expect(nextTabIndex(0, 'ArrowLeft', 3)).toBe(2);
+	});
+
+	test('Home and End jump to the ends', () => {
+		expect(nextTabIndex(1, 'Home', 3)).toBe(0);
+		expect(nextTabIndex(1, 'End', 3)).toBe(2);
+	});
+
+	test('digits 1-8 are absolute positions', () => {
+		expect(nextTabIndex(0, '1', 5)).toBe(0);
+		expect(nextTabIndex(0, '3', 5)).toBe(2);
+		expect(nextTabIndex(0, '5', 5)).toBe(4);
+	});
+
+	test('9 means the last tab, however many there are', () => {
+		expect(nextTabIndex(0, '9', 3)).toBe(2);
+		expect(nextTabIndex(0, '9', 12)).toBe(11);
+	});
+
+	test('a digit past the end is ignored rather than clamped', () => {
+		expect(nextTabIndex(0, '5', 3)).toBeNull();
+		expect(nextTabIndex(0, '8', 3)).toBeNull();
+	});
+
+	test('unhandled keys pass through', () => {
+		for (const key of ['ArrowUp', 'Enter', 'a', '0', 'Tab', ' ']) {
+			expect(nextTabIndex(0, key, 3)).toBeNull();
+		}
+	});
+
+	test('an empty strip never resolves', () => {
+		for (const key of ['ArrowRight', 'Home', 'End', '1', '9']) {
+			expect(nextTabIndex(0, key, 0)).toBeNull();
+		}
+	});
+
+	test('an out-of-range current index still resolves', () => {
+		expect(nextTabIndex(-1, 'ArrowRight', 3)).toBe(1);
+		expect(nextTabIndex(99, 'ArrowLeft', 3)).toBe(2);
+	});
+});

--- a/src/lib/tab-nav.ts
+++ b/src/lib/tab-nav.ts
@@ -1,0 +1,30 @@
+/** Digit jumps follow the browser convention: 1–8 are absolute, 9 is always the last tab. */
+function digitTarget(digit: number, count: number): number {
+	return digit === 9 ? count - 1 : digit - 1;
+}
+
+/**
+ * Index the tab strip should move to for a key, or `null` to leave the event alone.
+ * Pure so the arrow/Home/End/digit math is testable without a DOM.
+ */
+export function nextTabIndex(current: number, key: string, count: number): number | null {
+	if (count <= 0) return null;
+	// A `current` outside the strip (nothing focused yet) still resolves, since the
+	// arrow branches below normalise through a modulo of `count`.
+	const from = current < 0 || current >= count ? 0 : current;
+	switch (key) {
+		case 'ArrowRight':
+			return (from + 1) % count;
+		case 'ArrowLeft':
+			return (from - 1 + count) % count;
+		case 'Home':
+			return 0;
+		case 'End':
+			return count - 1;
+		default: {
+			if (!/^[1-9]$/.test(key)) return null;
+			const target = digitTarget(Number(key), count);
+			return target < count ? target : null;
+		}
+	}
+}


### PR DESCRIPTION
The tab strip at the top of `/ide/:id` was the last surface still outside the app's visual language. It used `--rule-soft` hairlines — weaker than the `--rule` dividers the home and cog buttons in the *same bar* already use — a flat ink block for the active tab, and an attention pulse that washed the whole tab background green/amber, fighting the active fill instead of reading as a signal.

## The design

Tabs are now **pressed-key slabs**, built entirely from patterns already in the repo (no new tokens):

| Element | Treatment |
|---|---|
| Divider | `--rule`, matching the home/cog rules beside it |
| Idle | Transparent on the bar's `--bg-card`, label `--ink-soft` |
| Hover | 12% `--ink` tint, label to `--ink` |
| Active | `--ink` fill, `--bg` label, plus `inset 0 3px 0 var(--bg)` — the slot the key sank out of |
| Label | `--font-display` (Doto) 13px/700, matching the `.panel-bar` strips elsewhere |
| Avatar | `scale={3}` — real clearance in the 44px bar, and better balance against a 13px label |
| Container type | The mode icon promoted to an 18px bordered chip |
| Attention | The dashboard card's discrete LED square. No background wash |

Hover is a tint rather than the house inversion idiom because inversion is *also* the active state here; a tint keeps idle → hover → active legible as three steps. `color-mix` tints are established vocabulary (`--switch-on-bg`, the busy scrim).

The avatar, name, and container type all stay — that was the constraint.

## Interaction gaps fixed along the way

- **Tablist semantics.** `role="tablist"` / `role="tab"` / `aria-selected` and a roving `tabindex`, so the strip is one tab stop instead of walking through every instance before reaching the reload and cog buttons. Each tab now announces as `tab "meridian MERIDIAN Terminal-only instance Claude is waiting for input" selected` — previously it was bare divs conveying state through background color alone. Panes get the matching `role="tabpanel"` + `aria-labelledby`.
- **Keyboard navigation.** Arrow Left/Right/Home/End, plus `Alt+1`–`9` to jump (9 = last). Worth knowing: these only fire while the shell chrome has focus — a focused code-server iframe swallows keydown before it reaches the document. The index math is extracted to `src/lib/tab-nav.ts` and unit tested.
- **Overflow.** The raw `overflow-x: auto` scrollbar ate into a 44px bar. It's hidden now, replaced by chevron scroll buttons that appear only on overflow and disable at each end, and the selected tab is scrolled into view (needed now that the keyboard can select an off-screen tab).
- **Rename input** gets the `--ink` border and standard focus ring, and no longer reflows the strip mid-edit.

Every animation keeps its `prefers-reduced-motion` opt-out, per the codebase rule.

## Reviewing it

Adds an `IdeBar` entry to the `/debug` showcase covering every state — tab count, active index, attention, mixed modes, long-name truncation, and live rename. This is also the **only** way to review the bar without a Docker daemon, since tabs only render for running instances.

```
bun run dev   # then http://localhost:6969/debug → IDEBAR
```

## Verification

`bun run checks` clean. Verified in Chrome across light and dark themes: the three-step hover ladder, focus rings (including the `--bg` outline on the inverted active tab), Arrow/Home/End/Alt+digit selection, scroll-into-view, chevron disabled states at each end, name truncation, and a clean console.
