### PR TITLE
chore(devcontainer): install Google Chrome for the DevTools MCP

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
 			"onAutoForward": "notify"
 		}
 	},
-	"postCreateCommand": "bun install",
+	"postCreateCommand": "bun install && sudo bash .devcontainer/install-chrome.sh",
 	"customizations": {
 		"vscode": {
 			"extensions": ["svelte.svelte-vscode", "dbaeumer.vscode-eslint", "esbenp.prettier-vscode"],

--- a/.devcontainer/install-chrome.sh
+++ b/.devcontainer/install-chrome.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Installs Google Chrome (stable) so the chrome-devtools MCP can drive a real
+# browser out of the box. The .deb lands the binary at /opt/google/chrome/chrome
+# — the exact path the MCP probes for the "stable" channel — so no symlink or
+# MCP config is needed. Idempotent; run as root (postCreateCommand uses sudo).
+set -euo pipefail
+
+if [ -x /opt/google/chrome/chrome ]; then
+	echo "Chrome already present at /opt/google/chrome/chrome — skipping."
+	exit 0
+fi
+
+# Chrome for Linux ships amd64 only; skip (don't fail the build) elsewhere so
+# arm64 hosts like Apple Silicon still get a working container, just no Chrome.
+arch="$(dpkg --print-architecture)"
+if [ "$arch" != "amd64" ]; then
+	echo "Google Chrome for Linux is amd64-only; detected '$arch' — skipping." >&2
+	echo "The chrome-devtools MCP will have no browser on this architecture." >&2
+	exit 0
+fi
+
+deb="$(mktemp --suffix=.deb)"
+curl -fsSL https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb -o "$deb"
+apt-get update
+apt-get install -y "$deb"
+rm -f "$deb"
+echo "Chrome installed at /opt/google/chrome/chrome"


### PR DESCRIPTION
## What

Adds a `postCreateCommand` step to the dev container that installs Google Chrome (stable) via a small idempotent script.

```jsonc
"postCreateCommand": "bun install && sudo bash .devcontainer/install-chrome.sh",
```

## Why

The dev container is Bun-only and ships **no browser**, so the `chrome-devtools` MCP can't attach — the first `new_page` fails with:

```
Could not find Google Chrome executable for channel 'stable' at:
 - /opt/google/chrome/chrome
```

The `google-chrome-stable` `.deb` installs the binary at **exactly** `/opt/google/chrome/chrome` — the path the MCP probes for the `stable` channel — so **no symlink and no MCP config change is needed**. apt alone is enough.

## Script behaviour (`.devcontainer/install-chrome.sh`)

- **Idempotent** — skips if `/opt/google/chrome/chrome` already exists.
- **Arch-safe** — Chrome for Linux is amd64-only, so on non-amd64 hosts (e.g. Apple-Silicon devcontainers) it prints a warning and exits 0 rather than failing the whole `postCreateCommand`. The container still builds; it just has no browser for the MCP there.

## Verification (run live in this devcontainer)

- Removed a test symlink, ran the script as `postCreateCommand` would (`sudo bash .devcontainer/install-chrome.sh`) → installed **Google Chrome 151.0.7922.137**.
- Confirmed `/opt/google/chrome/chrome` is a real 291 MB binary (not a symlink).
- Confirmed the `chrome-devtools` MCP attaches to it (`new_page` succeeds) — no symlink, no extra config.
- `bun run checks` clean — format, eslint, typecheck (0 errors), 388 tests pass.

## Note

This adds ~300 MB (plus deps) and some build time to every contributor's container, solely so AI-driven browser profiling via the MCP works out of the box. Easy to flip to an opt-in `.devcontainer/install-chrome.sh` a contributor runs on demand instead — say the word and I'll adjust.