### PR TITLE
feat: make tab keyboard shortcuts toggleable in settings

### DIFF
--- a/src/components/AppShell.svelte
+++ b/src/components/AppShell.svelte
@@ -9,6 +9,7 @@
 	import IdeLoader from './IdeLoader.svelte';
 	import TerminalSplit from './TerminalSplit.svelte';
 	import { playChime, unlockAudio } from '../sound.ts';
+	import { tabShortcutsEnabled } from '../settings.ts';
 	import { liveStream } from '../live.ts';
 	import { apiPost } from '../api.ts';
 	import { syncTheme } from '../theme.ts';
@@ -189,7 +190,7 @@
 	// for its own tabs and can't be intercepted, and Ctrl+Alt is AltGr on many European
 	// layouts, so it would collide with typing punctuation.
 	function jumpToTab(e: KeyboardEvent, fromFrame: boolean) {
-		if (!e.altKey || e.ctrlKey || e.metaKey || editingId) return;
+		if (!e.altKey || e.ctrlKey || e.metaKey || editingId || !tabShortcutsEnabled()) return;
 		// `code`, not `key`: Alt+digit emits punctuation on macOS layouts.
 		const digit = /^Digit([1-9])$/.exec(e.code)?.[1];
 		if (!digit) return;

--- a/src/components/SettingsView.svelte
+++ b/src/components/SettingsView.svelte
@@ -4,6 +4,7 @@
 	import Power from '@lucide/svelte/icons/power';
 	import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
 	import Volume2 from '@lucide/svelte/icons/volume-2';
+	import Keyboard from '@lucide/svelte/icons/keyboard';
 	import PawPrint from '@lucide/svelte/icons/paw-print';
 	import SunMoon from '@lucide/svelte/icons/sun-moon';
 	import ThemePicker from './ThemePicker.svelte';
@@ -27,7 +28,12 @@
 	import { flushSync } from 'svelte';
 	import { enhance } from 'mochi-framework';
 	import type { MochiEnhanceOptions } from 'mochi-framework';
-	import { soundEnabled, setSoundEnabled } from '../settings.ts';
+	import {
+		soundEnabled,
+		setSoundEnabled,
+		tabShortcutsEnabled,
+		setTabShortcutsEnabled
+	} from '../settings.ts';
 	import { playChime, unlockAudio } from '../sound.ts';
 	import Button from './Button.svelte';
 	import CoinButton from './CoinButton.svelte';
@@ -133,6 +139,7 @@
 
 	// Defaults to on during SSR, where localStorage doesn't exist.
 	let sound = $state(soundEnabled());
+	let tabShortcuts = $state(tabShortcutsEnabled());
 
 	// DB-backed, so it initializes from the prop. Undefined is the off state — the header keeps its box logo.
 	// svelte-ignore state_referenced_locally
@@ -778,6 +785,11 @@
 		// A toggle is a user gesture — unlock audio and preview when enabling.
 		unlockAudio();
 		if (on) playChime('done');
+	}
+
+	function toggleTabShortcuts(on: boolean) {
+		tabShortcuts = on;
+		setTabShortcutsEnabled(on);
 	}
 
 	// State is object-shaped (the chosen sprite), so this can't reuse the boolean `toggleOpts`.
@@ -1974,6 +1986,29 @@
 						type="checkbox"
 						checked={sound}
 						onchange={(e) => toggleSound(e.currentTarget.checked)}
+					/>
+					<span class="track"><span class="thumb"></span></span>
+				</label>
+			</div>
+		</section>
+
+		<section class="card">
+			<div class="row">
+				<div class="label">
+					<Keyboard size={20} />
+					<div class="text">
+						<div class="name">Tab keyboard shortcuts</div>
+						<div class="desc">
+							Jump between open instance tabs with <code>Alt</code>+<code>1</code>–<code>9</code> (9 is
+							always the last tab). Turn off to leave those keystrokes to the editor.
+						</div>
+					</div>
+				</div>
+				<label class="switch">
+					<input
+						type="checkbox"
+						checked={tabShortcuts}
+						onchange={(e) => toggleTabShortcuts(e.currentTarget.checked)}
 					/>
 					<span class="track"><span class="thumb"></span></span>
 				</label>

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,3 +12,16 @@ export function setSoundEnabled(on: boolean): void {
 	if (typeof localStorage === 'undefined') return;
 	localStorage.setItem(SOUND_KEY, on ? 'on' : 'off');
 }
+
+const TAB_SHORTCUTS_KEY = 'codebay.tabShortcuts';
+
+/** Defaults to on — only an explicit 'off' disables the Alt+1-9 tab jumps. */
+export function tabShortcutsEnabled(): boolean {
+	if (typeof localStorage === 'undefined') return true;
+	return localStorage.getItem(TAB_SHORTCUTS_KEY) !== 'off';
+}
+
+export function setTabShortcutsEnabled(on: boolean): void {
+	if (typeof localStorage === 'undefined') return;
+	localStorage.setItem(TAB_SHORTCUTS_KEY, on ? 'on' : 'off');
+}


### PR DESCRIPTION
## What

Adds a **Tab keyboard shortcuts** switch to `/settings` that turns off the `Alt`+`1`–`9` tab-jump shortcuts.

## Why

The Alt+digit shortcuts intercept keystrokes inside every editor/terminal pane (installed capture-phase inside each same-origin iframe). Users who don't use them — or who hit collisions with editor bindings — had no way to disable them.

## How

- `src/settings.ts`: new `tabShortcutsEnabled()` / `setTabShortcutsEnabled()`, a `localStorage`-backed client-only preference defaulting to **on**, mirroring the existing `soundEnabled` sound toggle.
- `src/components/AppShell.svelte`: `jumpToTab` now short-circuits when the setting is off. It reads the flag on each keystroke, so toggling takes effect without a page reload and across the in-iframe listeners.
- `src/components/SettingsView.svelte`: a new switch card (keyboard icon) next to **Attention sound**, since both are client-only UI prefs.

## Testing

`bun run checks` passes (format + eslint + typecheck + 388 tests; the 3 svelte-check warnings are pre-existing in `AvatarEditor.svelte`).