### PR TITLE
fix: keep code-server dark from the first frame

### DIFF
--- a/src/components/AppShell.svelte
+++ b/src/components/AppShell.svelte
@@ -440,6 +440,9 @@
 		height: 100%;
 		border: 0;
 		display: block;
+		/* An embedded document takes its prefers-color-scheme from the embedder, so without this
+		   Codebay's own light theme makes code-server's startup theme resolve light. */
+		color-scheme: dark;
 	}
 	.empty {
 		position: absolute;

--- a/src/container-injections/code-server-dark.ts
+++ b/src/container-injections/code-server-dark.ts
@@ -1,0 +1,185 @@
+import { execInContainer, type ExecTarget } from '../lib/exec.server.ts';
+import { editJsonFile, readJsonFile } from '../lib/container-files.server.ts';
+import type { Injection } from '../lib/injections.server.ts';
+
+/**
+ * Walks up from the resolved binary rather than assuming /usr/lib/code-server: the feature and the
+ * standalone tarball put the wrapper at different depths, and only one of the two layouts keeps the
+ * bundled VS Code directly above `bin/`. Prints the root on the last line — `bash -lc` runs profile
+ * scripts whose stdout comes first, so callers must read the last line, never the whole capture.
+ */
+export const RESOLVE_ROOT_SCRIPT =
+	`p=$(command -v code-server) || exit 1; p=$(readlink -f "$p"); ` +
+	`while [ "$p" != "/" ]; do ` +
+	`for c in "$p" "$p/lib/vscode"; do ` +
+	`[ -d "$c/extensions/theme-defaults" ] && { printf '\\n%s\\n' "$c"; exit 0; }; done; ` +
+	`p=$(dirname "$p"); done; exit 1`;
+
+/** The exec user's own code-server state; the theme cache below must be dropped from it. */
+const CACHED_EXTENSIONS = '~/.local/share/code-server/CachedExtensions';
+
+const SETTINGS_DIR = '$h/.local/share/code-server/User';
+
+/**
+ * The settings value VS Code compares against is the theme's *label*, so it moves with the build:
+ * 1.131 ships `Dark 2026`, older ones `Dark Modern`, older still the `Default …` spelling. Matching
+ * it exactly is what stops the workbench discarding its own persisted theme on every boot.
+ */
+const DARK_LABEL_KEYS = ['dark2026ThemeLabel', 'darkModernThemeLabel'];
+
+export const FALLBACK_DARK_THEME = 'Default Dark Modern';
+
+const THEME_KEYS = [
+	'workbench.colorTheme',
+	'workbench.preferredDarkColorTheme',
+	'workbench.preferredLightColorTheme'
+];
+
+/** A root path we are about to interpolate into a shell script, so nothing exotic may pass. */
+const SAFE_PATH = /^\/[A-Za-z0-9._+\-/]+$/;
+
+/** Mirrors `checkPresence`: only the last line is ours, everything before it is login-shell noise. */
+function lastLine(stdout: string): string {
+	return stdout.trimEnd().split('\n').pop()?.trim() ?? '';
+}
+
+export function pickDarkLabel(nls: Record<string, unknown> | null): string {
+	for (const key of DARK_LABEL_KEYS) {
+		const value = nls?.[key];
+		if (typeof value === 'string' && value.trim()) return value.trim();
+	}
+	return FALLBACK_DARK_THEME;
+}
+
+interface ThemeContribution {
+	uiTheme?: string;
+	path?: string;
+}
+
+/**
+ * Selecting by `uiTheme` rather than by filename is load-bearing: the light set is
+ * 2026-light/light_modern/light_plus/light_vs *and* hc_light, so a `light*.json` glob silently
+ * misses two of them. Repointing `path` too, since the light JSONs stay light on disk.
+ */
+export function darkenThemeManifest(manifest: Record<string, unknown>): {
+	next: Record<string, unknown>;
+	changed: number;
+} {
+	const contributes = manifest.contributes;
+	if (typeof contributes !== 'object' || contributes === null)
+		return { next: manifest, changed: 0 };
+	const themes = (contributes as Record<string, unknown>).themes;
+	if (!Array.isArray(themes)) return { next: manifest, changed: 0 };
+
+	const darkPath = themes.find(
+		(t: ThemeContribution) => t?.uiTheme === 'vs-dark' && typeof t.path === 'string'
+	)?.path as string | undefined;
+	const hcDarkPath = themes.find(
+		(t: ThemeContribution) => t?.uiTheme === 'hc-black' && typeof t.path === 'string'
+	)?.path as string | undefined;
+
+	let changed = 0;
+	const nextThemes = themes.map((theme: ThemeContribution) => {
+		if (theme?.uiTheme === 'vs' && darkPath) {
+			changed++;
+			return { ...theme, uiTheme: 'vs-dark', path: darkPath };
+		}
+		if (theme?.uiTheme === 'hc-light' && hcDarkPath) {
+			changed++;
+			return { ...theme, uiTheme: 'hc-black', path: hcDarkPath };
+		}
+		return theme;
+	});
+
+	return {
+		next: { ...manifest, contributes: { ...contributes, themes: nextThemes } },
+		changed
+	};
+}
+
+/**
+ * Whitespace-tolerant because the shipped manifest is minified (`"uiTheme":"vs"`) while our own
+ * rewrite pretty-prints it — a fixed-spacing pattern would miss the unpatched file and report green.
+ * The closing quote is what keeps `"vs"` from also matching `"vs-dark"`.
+ */
+const LIGHT_UI_THEME_RE = '"uiTheme"[[:space:]]*:[[:space:]]*"(vs|hc-light)"';
+
+export const checkScript = (root: string): string =>
+	`m="${root}/extensions/theme-defaults/package.json"; ` +
+	`[ -f "$m" ] && ! grep -qE '${LIGHT_UI_THEME_RE}' "$m" && echo 1 || echo 0`;
+
+/** Root, since the bundled VS Code tree isn't owned by the remote user. */
+const rootTarget = (target: ExecTarget): ExecTarget => ({ containerId: target.containerId });
+
+async function resolveRoot(target: ExecTarget): Promise<string | null> {
+	const res = await execInContainer(rootTarget(target), {
+		script: RESOLVE_ROOT_SCRIPT,
+		capture: true
+	});
+	if (!res.ok) return null;
+	const root = lastLine(res.stdout);
+	return SAFE_PATH.test(root) ? root : null;
+}
+
+/**
+ * VS Code Web's pre-extension paint falls back to `isWeb ? LIGHT : DARK` whenever it has no usable
+ * cached theme, so pinning the theme in settings alone can never keep the first frame dark. This
+ * closes both halves: it writes the theme id *this* build uses (so the cache survives), and rewrites
+ * the bundled manifest so the light themes render dark even if one is somehow selected.
+ */
+export const codeServerDark: Injection = {
+	id: 'code-server-dark',
+	label: 'code-server dark theme',
+	// code-server-only; terminal-mode instances never run a workbench.
+	modes: ['ide'],
+
+	async apply(target, log) {
+		log('Forcing code-server dark theme…\n');
+		const root = await resolveRoot(target);
+		if (!root) {
+			log('⚠ code-server install not found — dark theme left to the staged settings\n');
+			return;
+		}
+
+		const themeDir = `${root}/extensions/theme-defaults`;
+		const nls = await readJsonFile(rootTarget(target), {
+			dir: themeDir,
+			name: 'package.nls.json'
+		});
+		const darkTheme = pickDarkLabel(nls);
+
+		const settings = await editJsonFile(
+			target,
+			{ dir: SETTINGS_DIR, name: 'settings.json' },
+			(current) => ({ ...current, ...Object.fromEntries(THEME_KEYS.map((k) => [k, darkTheme])) })
+		);
+		log(
+			settings.ok
+				? `✓ Pinned code-server theme to "${darkTheme}"\n`
+				: `⚠ Could not pin the code-server theme: ${settings.error}\n`
+		);
+
+		const manifest = await editJsonFile(
+			rootTarget(target),
+			{ dir: themeDir, name: 'package.json' },
+			(current) => darkenThemeManifest(current).next
+		);
+		if (!manifest.ok) {
+			log(`⚠ Could not darken the built-in light themes: ${manifest.error}\n`);
+			return;
+		}
+		// The manifest is cached per install, so the rewrite is invisible until the cache is dropped.
+		await execInContainer(target, { script: `rm -rf ${CACHED_EXTENSIONS} 2>/dev/null || true` });
+		log('✓ Built-in light themes now render dark\n');
+	},
+
+	async check(target) {
+		const root = await resolveRoot(target);
+		if (!root) return false;
+		const res = await execInContainer(rootTarget(target), {
+			script: checkScript(root),
+			capture: true
+		});
+		return res.ok && lastLine(res.stdout) === '1';
+	}
+};

--- a/src/container-injections/code-server-dark.ts
+++ b/src/container-injections/code-server-dark.ts
@@ -1,6 +1,12 @@
-import { execInContainer, type ExecTarget } from '../lib/exec.server.ts';
+import { checkPresence, execInContainer, type ExecTarget } from '../lib/exec.server.ts';
 import { editJsonFile, readJsonFile } from '../lib/container-files.server.ts';
+import { CODE_SERVER_SETTINGS } from '../lib/devcontainer.server.ts';
 import type { Injection } from '../lib/injections.server.ts';
+
+/** Locates the bundled VS Code from the binary; shared prelude for the resolve and the check. */
+const WALK_TO_BUNDLE =
+	`p=$(command -v code-server) || exit 1; p=$(readlink -f "$p"); ` +
+	`while [ "$p" != "/" ]; do for c in "$p" "$p/lib/vscode"; do `;
 
 /**
  * Walks up from the resolved binary rather than assuming /usr/lib/code-server: the feature and the
@@ -9,25 +15,47 @@ import type { Injection } from '../lib/injections.server.ts';
  * scripts whose stdout comes first, so callers must read the last line, never the whole capture.
  */
 export const RESOLVE_ROOT_SCRIPT =
-	`p=$(command -v code-server) || exit 1; p=$(readlink -f "$p"); ` +
-	`while [ "$p" != "/" ]; do ` +
-	`for c in "$p" "$p/lib/vscode"; do ` +
+	WALK_TO_BUNDLE +
 	`[ -d "$c/extensions/theme-defaults" ] && { printf '\\n%s\\n' "$c"; exit 0; }; done; ` +
 	`p=$(dirname "$p"); done; exit 1`;
 
-/** The exec user's own code-server state; the theme cache below must be dropped from it. */
-const CACHED_EXTENSIONS = '~/.local/share/code-server/CachedExtensions';
+/**
+ * Whitespace-tolerant because the shipped manifest is minified (`"uiTheme":"vs"`) while our own
+ * rewrite pretty-prints it — a fixed-spacing pattern would miss the unpatched file and report green.
+ * The closing quote is what keeps `"vs"` from also matching `"vs-dark"`.
+ */
+const LIGHT_UI_THEME_RE = '"uiTheme"[[:space:]]*:[[:space:]]*"(vs|hc-light)"';
+
+/**
+ * Resolve and probe in one exec: `check()` runs on every health tick, in the same `Promise.all` as
+ * the `codeServerAccessible` probe that gates mounting the IDE iframe, so a second round trip here
+ * would slow the boot-time fast cadence for no gain — the root can't move for a container's life.
+ */
+export const CHECK_SCRIPT =
+	WALK_TO_BUNDLE +
+	`m="$c/extensions/theme-defaults/package.json"; ` +
+	`[ -f "$m" ] && { grep -qE '${LIGHT_UI_THEME_RE}' "$m" && echo 0 || echo 1; exit 0; }; done; ` +
+	`p=$(dirname "$p"); done; echo 0`;
+
+/**
+ * The builtin-extension scan is cached against the mtime of the `extensions/` **directory**, which
+ * rewriting a manifest inside it does not touch — so without invalidating both the cache file and
+ * that mtime, the running server and the next window keep serving the pre-rewrite themes.
+ */
+const CLEAR_BUILTIN_CACHE =
+	`rm -f ~/.local/share/code-server/CachedProfilesData/*/extensions.builtin.cache 2>/dev/null; ` +
+	`exit 0`;
 
 const SETTINGS_DIR = '$h/.local/share/code-server/User';
 
 /**
- * The settings value VS Code compares against is the theme's *label*, so it moves with the build:
- * 1.131 ships `Dark 2026`, older ones `Dark Modern`, older still the `Default …` spelling. Matching
- * it exactly is what stops the workbench discarding its own persisted theme on every boot.
+ * VS Code matches `workbench.colorTheme` against a theme's *settingsId*, which is its manifest `id`
+ * (the label is only a fallback for entries without one) — so this reads ids, never the nls labels.
+ * The order tracks the build default (`ThemeSettingDefaults.COLOR_THEME_DARK`) across versions,
+ * because pinning exactly that id is what lets the workbench paint its real dark colors before any
+ * extension loads. Anything unrecognised falls back to whatever dark theme the build does ship.
  */
-const DARK_LABEL_KEYS = ['dark2026ThemeLabel', 'darkModernThemeLabel'];
-
-export const FALLBACK_DARK_THEME = 'Default Dark Modern';
+const PREFERRED_DARK_IDS = ['Dark 2026', 'Default Dark Modern', 'Dark Modern', 'Dark+'];
 
 const THEME_KEYS = [
 	'workbench.colorTheme',
@@ -43,17 +71,26 @@ function lastLine(stdout: string): string {
 	return stdout.trimEnd().split('\n').pop()?.trim() ?? '';
 }
 
-export function pickDarkLabel(nls: Record<string, unknown> | null): string {
-	for (const key of DARK_LABEL_KEYS) {
-		const value = nls?.[key];
-		if (typeof value === 'string' && value.trim()) return value.trim();
-	}
-	return FALLBACK_DARK_THEME;
-}
-
 interface ThemeContribution {
+	id?: string;
 	uiTheme?: string;
 	path?: string;
+}
+
+function themesOf(manifest: Record<string, unknown>): ThemeContribution[] | null {
+	const contributes = manifest.contributes;
+	if (typeof contributes !== 'object' || contributes === null) return null;
+	const themes = (contributes as Record<string, unknown>).themes;
+	return Array.isArray(themes) ? (themes as ThemeContribution[]) : null;
+}
+
+/** Null when the build ships no identifiable dark theme — better to leave the staged settings alone than pin an id nothing resolves. */
+export function pickDarkThemeId(manifest: Record<string, unknown>): string | null {
+	const ids = (themesOf(manifest) ?? [])
+		.filter((t) => t?.uiTheme === 'vs-dark' && typeof t.id === 'string' && t.id.trim())
+		.map((t) => t.id!.trim());
+	if (!ids.length) return null;
+	return PREFERRED_DARK_IDS.find((id) => ids.includes(id)) ?? ids[0]!;
 }
 
 /**
@@ -65,21 +102,16 @@ export function darkenThemeManifest(manifest: Record<string, unknown>): {
 	next: Record<string, unknown>;
 	changed: number;
 } {
-	const contributes = manifest.contributes;
-	if (typeof contributes !== 'object' || contributes === null)
-		return { next: manifest, changed: 0 };
-	const themes = (contributes as Record<string, unknown>).themes;
-	if (!Array.isArray(themes)) return { next: manifest, changed: 0 };
+	const themes = themesOf(manifest);
+	if (!themes) return { next: manifest, changed: 0 };
 
-	const darkPath = themes.find(
-		(t: ThemeContribution) => t?.uiTheme === 'vs-dark' && typeof t.path === 'string'
-	)?.path as string | undefined;
-	const hcDarkPath = themes.find(
-		(t: ThemeContribution) => t?.uiTheme === 'hc-black' && typeof t.path === 'string'
-	)?.path as string | undefined;
+	const pathFor = (ui: string) =>
+		themes.find((t) => t?.uiTheme === ui && typeof t.path === 'string')?.path;
+	const darkPath = pathFor('vs-dark');
+	const hcDarkPath = pathFor('hc-black');
 
 	let changed = 0;
-	const nextThemes = themes.map((theme: ThemeContribution) => {
+	const nextThemes = themes.map((theme) => {
 		if (theme?.uiTheme === 'vs' && darkPath) {
 			changed++;
 			return { ...theme, uiTheme: 'vs-dark', path: darkPath };
@@ -91,31 +123,18 @@ export function darkenThemeManifest(manifest: Record<string, unknown>): {
 		return theme;
 	});
 
+	const contributes = manifest.contributes as Record<string, unknown>;
 	return {
 		next: { ...manifest, contributes: { ...contributes, themes: nextThemes } },
 		changed
 	};
 }
 
-/**
- * Whitespace-tolerant because the shipped manifest is minified (`"uiTheme":"vs"`) while our own
- * rewrite pretty-prints it — a fixed-spacing pattern would miss the unpatched file and report green.
- * The closing quote is what keeps `"vs"` from also matching `"vs-dark"`.
- */
-const LIGHT_UI_THEME_RE = '"uiTheme"[[:space:]]*:[[:space:]]*"(vs|hc-light)"';
-
-export const checkScript = (root: string): string =>
-	`m="${root}/extensions/theme-defaults/package.json"; ` +
-	`[ -f "$m" ] && ! grep -qE '${LIGHT_UI_THEME_RE}' "$m" && echo 1 || echo 0`;
-
-/** Root, since the bundled VS Code tree isn't owned by the remote user. */
+/** Only the writes need root; resolution runs as the remote user, whose PATH also carries a per-user standalone install. */
 const rootTarget = (target: ExecTarget): ExecTarget => ({ containerId: target.containerId });
 
 async function resolveRoot(target: ExecTarget): Promise<string | null> {
-	const res = await execInContainer(rootTarget(target), {
-		script: RESOLVE_ROOT_SCRIPT,
-		capture: true
-	});
+	const res = await execInContainer(target, { script: RESOLVE_ROOT_SCRIPT, capture: true });
 	if (!res.ok) return null;
 	const root = lastLine(res.stdout);
 	return SAFE_PATH.test(root) ? root : null;
@@ -124,8 +143,8 @@ async function resolveRoot(target: ExecTarget): Promise<string | null> {
 /**
  * VS Code Web's pre-extension paint falls back to `isWeb ? LIGHT : DARK` whenever it has no usable
  * cached theme, so pinning the theme in settings alone can never keep the first frame dark. This
- * closes both halves: it writes the theme id *this* build uses (so the cache survives), and rewrites
- * the bundled manifest so the light themes render dark even if one is somehow selected.
+ * closes both halves: it pins the theme id *this* build uses (so the workbench stops discarding its
+ * own cache), and rewrites the bundled manifest so the light themes render dark if one is selected.
  */
 export const codeServerDark: Injection = {
 	id: 'code-server-dark',
@@ -142,44 +161,56 @@ export const codeServerDark: Injection = {
 		}
 
 		const themeDir = `${root}/extensions/theme-defaults`;
-		const nls = await readJsonFile(rootTarget(target), {
-			dir: themeDir,
-			name: 'package.nls.json'
-		});
-		const darkTheme = pickDarkLabel(nls);
+		const manifest = await readJsonFile(target, { dir: themeDir, name: 'package.json' });
+		if (!manifest) {
+			log('⚠ Could not read the bundled theme manifest — dark theme left to the staged settings\n');
+			return;
+		}
 
-		const settings = await editJsonFile(
-			target,
-			{ dir: SETTINGS_DIR, name: 'settings.json' },
-			(current) => ({ ...current, ...Object.fromEntries(THEME_KEYS.map((k) => [k, darkTheme])) })
-		);
-		log(
-			settings.ok
-				? `✓ Pinned code-server theme to "${darkTheme}"\n`
-				: `⚠ Could not pin the code-server theme: ${settings.error}\n`
-		);
+		const darkTheme = pickDarkThemeId(manifest);
+		if (!darkTheme) {
+			log('⚠ No dark theme found in the bundled manifest — staged settings left as they are\n');
+		} else {
+			// Seeded from the staged defaults so this still writes a complete file on the path where
+			// the launcher's own copy silently failed, rather than a settings.json of three keys.
+			const settings = await editJsonFile(
+				target,
+				{ dir: SETTINGS_DIR, name: 'settings.json' },
+				(current) => ({
+					...CODE_SERVER_SETTINGS,
+					...current,
+					...Object.fromEntries(THEME_KEYS.map((k) => [k, darkTheme]))
+				})
+			);
+			log(
+				settings.ok
+					? `✓ Pinned code-server theme to "${darkTheme}"\n`
+					: `⚠ Could not pin the code-server theme: ${settings.error}\n`
+			);
+		}
 
-		const manifest = await editJsonFile(
+		if (darkenThemeManifest(manifest).changed === 0) {
+			log('· No light themes to darken in this build\n');
+			return;
+		}
+		const written = await editJsonFile(
 			rootTarget(target),
 			{ dir: themeDir, name: 'package.json' },
 			(current) => darkenThemeManifest(current).next
 		);
-		if (!manifest.ok) {
-			log(`⚠ Could not darken the built-in light themes: ${manifest.error}\n`);
+		if (!written.ok) {
+			log(`⚠ Could not darken the built-in light themes: ${written.error}\n`);
 			return;
 		}
-		// The manifest is cached per install, so the rewrite is invisible until the cache is dropped.
-		await execInContainer(target, { script: `rm -rf ${CACHED_EXTENSIONS} 2>/dev/null || true` });
+		await execInContainer(target, { script: CLEAR_BUILTIN_CACHE });
+		// Bumping the scan's cache key; root because the bundled tree isn't the remote user's.
+		await execInContainer(rootTarget(target), {
+			script: `touch "${root}/extensions" 2>/dev/null; exit 0`
+		});
 		log('✓ Built-in light themes now render dark\n');
 	},
 
-	async check(target) {
-		const root = await resolveRoot(target);
-		if (!root) return false;
-		const res = await execInContainer(rootTarget(target), {
-			script: checkScript(root),
-			capture: true
-		});
-		return res.ok && lastLine(res.stdout) === '1';
+	check(target) {
+		return checkPresence(target, CHECK_SCRIPT);
 	}
 };

--- a/src/container-injections/injections.isolated.test.ts
+++ b/src/container-injections/injections.isolated.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { injections, resolveInjections, resolveInjectionStages } from '../lib/injections.server.ts';
@@ -34,10 +34,9 @@ import {
 	VERSION_RE
 } from './claude-code-update.ts';
 import {
-	checkScript,
+	CHECK_SCRIPT as DARK_CHECK_SCRIPT,
 	darkenThemeManifest,
-	FALLBACK_DARK_THEME,
-	pickDarkLabel,
+	pickDarkThemeId,
 	RESOLVE_ROOT_SCRIPT
 } from './code-server-dark.ts';
 
@@ -1321,14 +1320,30 @@ describe('claude-code-credentials LIVE_CREDENTIALS_TEST', () => {
 });
 
 describe('code-server-dark', () => {
-	// The real manifest's shape: a light and a dark entry per family, plus both high-contrast ones.
+	// The real manifest's shape: `id` is the settingsId VS Code matches against, and the label is
+	// an nls placeholder — which is exactly why the theme id must come from `id`, not the label.
 	const manifest = () => ({
 		contributes: {
 			themes: [
-				{ id: 'Light 2026', uiTheme: 'vs', path: './themes/2026-light.json' },
-				{ id: 'Dark 2026', uiTheme: 'vs-dark', path: './themes/2026-dark.json' },
-				{ id: 'Light Modern', uiTheme: 'vs', path: './themes/light_modern.json' },
-				{ id: 'Dark Modern', uiTheme: 'vs-dark', path: './themes/dark_modern.json' },
+				{ id: 'Light 2026', label: '%light2026%', uiTheme: 'vs', path: './themes/2026-light.json' },
+				{
+					id: 'Dark 2026',
+					label: '%dark2026%',
+					uiTheme: 'vs-dark',
+					path: './themes/2026-dark.json'
+				},
+				{
+					id: 'Light Modern',
+					label: '%lightModern%',
+					uiTheme: 'vs',
+					path: './themes/light_modern.json'
+				},
+				{
+					id: 'Dark Modern',
+					label: '%darkModern%',
+					uiTheme: 'vs-dark',
+					path: './themes/dark_modern.json'
+				},
 				{ id: 'Default High Contrast', uiTheme: 'hc-black', path: './themes/hc_black.json' },
 				{ id: 'Default High Contrast Light', uiTheme: 'hc-light', path: './themes/hc_light.json' }
 			]
@@ -1371,63 +1386,79 @@ describe('code-server-dark', () => {
 		expect(darkenThemeManifest({ contributes: { themes: 'nope' } }).changed).toBe(0);
 	});
 
-	test('prefers the newest dark label the build ships, then falls back', () => {
-		expect(
-			pickDarkLabel({ dark2026ThemeLabel: 'Dark 2026', darkModernThemeLabel: 'Dark Modern' })
-		).toBe('Dark 2026');
-		expect(pickDarkLabel({ darkModernThemeLabel: 'Dark Modern' })).toBe('Dark Modern');
-		expect(pickDarkLabel(null)).toBe(FALLBACK_DARK_THEME);
-		expect(pickDarkLabel({ dark2026ThemeLabel: '   ' })).toBe(FALLBACK_DARK_THEME);
+	// VS Code resolves settingsId as `theme.id || label`, so pinning the nls label would break on
+	// any build where the two differ — which is precisely the `Default Dark Modern` era.
+	test('pins the manifest id, preferring the build default, never the label', () => {
+		expect(pickDarkThemeId(manifest())).toBe('Dark 2026');
+		const older = {
+			contributes: {
+				themes: [
+					{ id: 'Dark Modern', label: 'Default Dark Modern', uiTheme: 'vs-dark', path: './d.json' }
+				]
+			}
+		};
+		expect(pickDarkThemeId(older)).toBe('Dark Modern');
 	});
 
-	// Run the resolver against a real temp tree, exactly as it would run in a container.
-	// The stub must be executable or `command -v` skips it — and on a box that has a real
-	// code-server (this repo dogfoods itself) it would then resolve that one instead.
-	function resolveIn(root: string): string {
+	test('falls back to whatever dark theme the build ships, and to null when there is none', () => {
+		const exotic = {
+			contributes: { themes: [{ id: 'Monokai', uiTheme: 'vs-dark', path: './m.json' }] }
+		};
+		expect(pickDarkThemeId(exotic)).toBe('Monokai');
+		// Writing a made-up id would be worse than leaving the staged settings alone.
+		expect(
+			pickDarkThemeId({ contributes: { themes: [{ id: 'L', uiTheme: 'vs', path: './l.json' }] } })
+		).toBe(null);
+		expect(pickDarkThemeId({})).toBe(null);
+	});
+
+	// Run the scripts against a real temp tree, exactly as they would run in a container. The stub
+	// must be executable or `command -v` skips it — and on a box that has a real code-server (this
+	// repo dogfoods itself) it would then resolve that one instead.
+	function stubbedRun(root: string, script: string): string {
 		const bin = join(root, 'bin');
 		mkdirSync(bin, { recursive: true });
 		writeFileSync(join(bin, 'code-server'), '#!/bin/sh\n', { mode: 0o755 });
-		const res = Bun.spawnSync(['bash', '-c', `PATH="${bin}:$PATH"; ${RESOLVE_ROOT_SCRIPT}`]);
+		const res = Bun.spawnSync(['bash', '-c', `PATH="${bin}:$PATH"; ${script}`]);
 		return res.stdout.toString().trimEnd().split('\n').pop()?.trim() ?? '';
 	}
 
 	test('finds the bundled VS Code in both install layouts', () => {
-		const tmp = mkdtempSync(join(tmpdir(), 'cs-dark-'));
+		// realpath: macOS resolves /var -> /private/var, which `readlink -f` in the script follows.
+		const tmp = realpathSync(mkdtempSync(join(tmpdir(), 'cs-dark-')));
 		try {
 			// Standalone: bin/ sits directly under the root that holds lib/vscode.
 			const standalone = join(tmp, 'standalone');
 			mkdirSync(join(standalone, 'lib', 'vscode', 'extensions', 'theme-defaults'), {
 				recursive: true
 			});
-			expect(resolveIn(standalone)).toBe(join(standalone, 'lib', 'vscode'));
+			expect(stubbedRun(standalone, RESOLVE_ROOT_SCRIPT)).toBe(join(standalone, 'lib', 'vscode'));
 
 			// Flat: the bundled tree is the root itself.
 			const flat = join(tmp, 'flat');
 			mkdirSync(join(flat, 'extensions', 'theme-defaults'), { recursive: true });
-			expect(resolveIn(flat)).toBe(flat);
+			expect(stubbedRun(flat, RESOLVE_ROOT_SCRIPT)).toBe(flat);
 		} finally {
 			rmSync(tmp, { recursive: true, force: true });
 		}
 	});
 
 	test('resolves nothing when no bundled VS Code is present', () => {
-		const tmp = mkdtempSync(join(tmpdir(), 'cs-dark-none-'));
+		const tmp = realpathSync(mkdtempSync(join(tmpdir(), 'cs-dark-none-')));
 		try {
-			expect(resolveIn(join(tmp, 'bare'))).toBe('');
+			expect(stubbedRun(join(tmp, 'bare'), RESOLVE_ROOT_SCRIPT)).toBe('');
 		} finally {
 			rmSync(tmp, { recursive: true, force: true });
 		}
 	});
 
-	test('check script rejects a manifest that still carries a light entry', () => {
-		const tmp = mkdtempSync(join(tmpdir(), 'cs-dark-check-'));
+	// One exec, because this runs on every health tick alongside the iframe-gating probe.
+	test('check script resolves and probes in a single pass', () => {
+		const tmp = realpathSync(mkdtempSync(join(tmpdir(), 'cs-dark-check-')));
 		try {
-			const dir = join(tmp, 'extensions', 'theme-defaults');
+			const dir = join(tmp, 'lib', 'vscode', 'extensions', 'theme-defaults');
 			mkdirSync(dir, { recursive: true });
-			const run = () =>
-				Bun.spawnSync(['bash', '-c', checkScript(tmp)])
-					.stdout.toString()
-					.trim();
+			const run = () => stubbedRun(tmp, DARK_CHECK_SCRIPT);
 
 			writeFileSync(join(dir, 'package.json'), JSON.stringify(manifest(), null, 2));
 			expect(run()).toBe('0');
@@ -1442,6 +1473,15 @@ describe('code-server-dark', () => {
 				JSON.stringify(darkenThemeManifest(manifest()).next, null, 2)
 			);
 			expect(run()).toBe('1');
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	test('check script reports 0 when there is no code-server at all', () => {
+		const tmp = realpathSync(mkdtempSync(join(tmpdir(), 'cs-dark-nocs-')));
+		try {
+			expect(stubbedRun(join(tmp, 'bare'), DARK_CHECK_SCRIPT)).toBe('0');
 		} finally {
 			rmSync(tmp, { recursive: true, force: true });
 		}

--- a/src/container-injections/injections.isolated.test.ts
+++ b/src/container-injections/injections.isolated.test.ts
@@ -33,6 +33,13 @@ import {
 	UPDATE_SCRIPT,
 	VERSION_RE
 } from './claude-code-update.ts';
+import {
+	checkScript,
+	darkenThemeManifest,
+	FALLBACK_DARK_THEME,
+	pickDarkLabel,
+	RESOLVE_ROOT_SCRIPT
+} from './code-server-dark.ts';
 
 describe('injection registry', () => {
 	test('every injection has a unique id', () => {
@@ -186,6 +193,7 @@ describe('resolveInjectionStages — clobber safety', () => {
 		'claude-code-credentials': ['claude-credentials', 'claude-json'],
 		'claude-code-custom': ['claude-env-file', 'rc', 'claude-json'],
 		'claude-code-ide-extension': ['extensions-dir'],
+		'code-server-dark': ['code-server-install', 'code-server-user-settings'],
 		'git-identity': ['gitconfig'],
 		'github-credentials': ['gh-hosts', 'gitconfig'],
 		'claude-effort-level': ['settings-json'],
@@ -1309,5 +1317,133 @@ describe('claude-code-credentials LIVE_CREDENTIALS_TEST', () => {
 	// the health check then reports as a live login, or a fresh container reads red.
 	test('accepts the record tokenCredentials injects', () => {
 		expect(isLive(tokenCredentials('sk-ant-oat01-abc'))).toBe(true);
+	});
+});
+
+describe('code-server-dark', () => {
+	// The real manifest's shape: a light and a dark entry per family, plus both high-contrast ones.
+	const manifest = () => ({
+		contributes: {
+			themes: [
+				{ id: 'Light 2026', uiTheme: 'vs', path: './themes/2026-light.json' },
+				{ id: 'Dark 2026', uiTheme: 'vs-dark', path: './themes/2026-dark.json' },
+				{ id: 'Light Modern', uiTheme: 'vs', path: './themes/light_modern.json' },
+				{ id: 'Dark Modern', uiTheme: 'vs-dark', path: './themes/dark_modern.json' },
+				{ id: 'Default High Contrast', uiTheme: 'hc-black', path: './themes/hc_black.json' },
+				{ id: 'Default High Contrast Light', uiTheme: 'hc-light', path: './themes/hc_light.json' }
+			]
+		}
+	});
+
+	test('repoints every light entry at a dark theme, high contrast included', () => {
+		const { next, changed } = darkenThemeManifest(manifest());
+		const themes = (next.contributes as { themes: { uiTheme: string; path: string }[] }).themes;
+		expect(changed).toBe(3);
+		expect(themes.every((t) => t.uiTheme === 'vs-dark' || t.uiTheme === 'hc-black')).toBe(true);
+		// The light JSONs stay light on disk, so leaving `path` alone would keep them light.
+		expect(themes.find((t) => t.path.includes('light'))).toBeUndefined();
+		expect(themes[5]!.path).toBe('./themes/hc_black.json');
+	});
+
+	// A filename glob would match 2026-light/light_modern/light_plus/light_vs but miss hc_light.
+	test('selects by uiTheme, not by filename', () => {
+		const odd = {
+			contributes: {
+				themes: [
+					{ id: 'Dark', uiTheme: 'vs-dark', path: './themes/dark_modern.json' },
+					{ id: 'Solarized', uiTheme: 'vs', path: './themes/solarized.json' }
+				]
+			}
+		};
+		const themes = (darkenThemeManifest(odd).next.contributes as { themes: { uiTheme: string }[] })
+			.themes;
+		expect(themes[1]!.uiTheme).toBe('vs-dark');
+	});
+
+	test('is idempotent — a second pass changes nothing', () => {
+		const once = darkenThemeManifest(manifest()).next;
+		expect(darkenThemeManifest(once).changed).toBe(0);
+	});
+
+	test('leaves a manifest it does not recognise alone', () => {
+		expect(darkenThemeManifest({}).changed).toBe(0);
+		expect(darkenThemeManifest({ contributes: {} }).changed).toBe(0);
+		expect(darkenThemeManifest({ contributes: { themes: 'nope' } }).changed).toBe(0);
+	});
+
+	test('prefers the newest dark label the build ships, then falls back', () => {
+		expect(
+			pickDarkLabel({ dark2026ThemeLabel: 'Dark 2026', darkModernThemeLabel: 'Dark Modern' })
+		).toBe('Dark 2026');
+		expect(pickDarkLabel({ darkModernThemeLabel: 'Dark Modern' })).toBe('Dark Modern');
+		expect(pickDarkLabel(null)).toBe(FALLBACK_DARK_THEME);
+		expect(pickDarkLabel({ dark2026ThemeLabel: '   ' })).toBe(FALLBACK_DARK_THEME);
+	});
+
+	// Run the resolver against a real temp tree, exactly as it would run in a container.
+	// The stub must be executable or `command -v` skips it — and on a box that has a real
+	// code-server (this repo dogfoods itself) it would then resolve that one instead.
+	function resolveIn(root: string): string {
+		const bin = join(root, 'bin');
+		mkdirSync(bin, { recursive: true });
+		writeFileSync(join(bin, 'code-server'), '#!/bin/sh\n', { mode: 0o755 });
+		const res = Bun.spawnSync(['bash', '-c', `PATH="${bin}:$PATH"; ${RESOLVE_ROOT_SCRIPT}`]);
+		return res.stdout.toString().trimEnd().split('\n').pop()?.trim() ?? '';
+	}
+
+	test('finds the bundled VS Code in both install layouts', () => {
+		const tmp = mkdtempSync(join(tmpdir(), 'cs-dark-'));
+		try {
+			// Standalone: bin/ sits directly under the root that holds lib/vscode.
+			const standalone = join(tmp, 'standalone');
+			mkdirSync(join(standalone, 'lib', 'vscode', 'extensions', 'theme-defaults'), {
+				recursive: true
+			});
+			expect(resolveIn(standalone)).toBe(join(standalone, 'lib', 'vscode'));
+
+			// Flat: the bundled tree is the root itself.
+			const flat = join(tmp, 'flat');
+			mkdirSync(join(flat, 'extensions', 'theme-defaults'), { recursive: true });
+			expect(resolveIn(flat)).toBe(flat);
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	test('resolves nothing when no bundled VS Code is present', () => {
+		const tmp = mkdtempSync(join(tmpdir(), 'cs-dark-none-'));
+		try {
+			expect(resolveIn(join(tmp, 'bare'))).toBe('');
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	test('check script rejects a manifest that still carries a light entry', () => {
+		const tmp = mkdtempSync(join(tmpdir(), 'cs-dark-check-'));
+		try {
+			const dir = join(tmp, 'extensions', 'theme-defaults');
+			mkdirSync(dir, { recursive: true });
+			const run = () =>
+				Bun.spawnSync(['bash', '-c', checkScript(tmp)])
+					.stdout.toString()
+					.trim();
+
+			writeFileSync(join(dir, 'package.json'), JSON.stringify(manifest(), null, 2));
+			expect(run()).toBe('0');
+
+			// code-server ships this file minified, so a fixed-spacing pattern would miss the
+			// unpatched manifest entirely and report the injection as already applied.
+			writeFileSync(join(dir, 'package.json'), JSON.stringify(manifest()));
+			expect(run()).toBe('0');
+
+			writeFileSync(
+				join(dir, 'package.json'),
+				JSON.stringify(darkenThemeManifest(manifest()).next, null, 2)
+			);
+			expect(run()).toBe('1');
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
 	});
 });

--- a/src/lib/devcontainer.isolated.test.ts
+++ b/src/lib/devcontainer.isolated.test.ts
@@ -68,6 +68,14 @@ describe('launchCommandFor', () => {
 		expect(postStart()).toContain(launchCommandFor('ide'));
 	});
 
+	// relaunchSurface re-runs this launcher after the injections have corrected the theme id for
+	// the installed build; an unconditional copy would put the stale staged id back.
+	test('ide launcher seeds code-server settings only when the file is missing', () => {
+		const launch = launchCommandFor('ide');
+		expect(launch).toContain('[ -f ~/.local/share/code-server/User/settings.json ] ||');
+		expect(launch).not.toMatch(/&&\s*cp -f/);
+	});
+
 	test('guards the code-server launch by port, not by a self-matching cmdline pattern', async () => {
 		await writeOverrideConfig(dir, 8001, [], undefined, 'ide');
 		// Any `pgrep -f` pattern matching a code-server daemon also matches this launcher's own

--- a/src/lib/devcontainer.isolated.test.ts
+++ b/src/lib/devcontainer.isolated.test.ts
@@ -257,11 +257,15 @@ describe('writeOverrideConfig terminal task + settings', () => {
 		expect(readSettings()['security.workspace.trust.enabled']).toBe(false);
 	});
 
-	test('pins a dark theme and disables auto color-scheme detection', async () => {
+	// Detection must stay ON: with it off, VS Code Web's pre-extension paint skips the preferred
+	// scheme entirely and falls back to a hardcoded light theme. Both preferred themes being dark
+	// is what makes leaving it on safe.
+	test('pins a dark theme on both preferred branches and leaves detection on', async () => {
 		await writeOverrideConfig(dir, 8001);
 		const settings = readSettings();
-		expect(settings['window.autoDetectColorScheme']).toBe(false);
+		expect(settings['window.autoDetectColorScheme']).toBe(true);
 		expect(settings['window.autoDetectHighContrast']).toBe(false);
+		expect(settings['workbench.colorTheme']).toBe('Default Dark Modern');
 		expect(settings['workbench.preferredDarkColorTheme']).toBe('Default Dark Modern');
 		expect(settings['workbench.preferredLightColorTheme']).toBe('Default Dark Modern');
 	});

--- a/src/lib/devcontainer.server.ts
+++ b/src/lib/devcontainer.server.ts
@@ -125,11 +125,16 @@ const EXCLUDE_MARKER_START = '# >>> codebay (auto-generated) >>>';
 const EXCLUDE_MARKER_END = '# <<< codebay <<<';
 
 const CODE_SERVER_SETTINGS = {
+	// Overwritten at boot by the code-server-dark injection with the id this build actually
+	// ships; the legacy label only has to carry a code-server old enough to still use it.
 	'workbench.colorTheme': 'Default Dark Modern',
-	// Stop VS Code re-resolving the theme from the OS/browser color scheme at runtime —
-	// that re-resolution (fired on focus/tab-switch) is what randomly flips the editor to
-	// light. Pinning both preferred themes to dark keeps either branch dark even if it does.
-	'window.autoDetectColorScheme': false,
+	// Counter-intuitive, and the opposite of what this file used to say: VS Code Web's
+	// pre-extension paint is `getPreferredColorScheme() ?? (isWeb ? LIGHT : DARK)`, and
+	// getPreferredColorScheme returns undefined unless detection is on — so turning detection
+	// OFF is what forced that first paint to light. On is only safe because both preferred
+	// themes below are the same dark theme, making either branch dark.
+	'window.autoDetectColorScheme': true,
+	// Left off so the high-contrast branch (which could resolve hcLight) stays unreachable.
 	'window.autoDetectHighContrast': false,
 	'workbench.preferredDarkColorTheme': 'Default Dark Modern',
 	'workbench.preferredLightColorTheme': 'Default Dark Modern',

--- a/src/lib/devcontainer.server.ts
+++ b/src/lib/devcontainer.server.ts
@@ -124,7 +124,7 @@ const MANAGER_GIT_EXCLUDES = [
 const EXCLUDE_MARKER_START = '# >>> codebay (auto-generated) >>>';
 const EXCLUDE_MARKER_END = '# <<< codebay <<<';
 
-const CODE_SERVER_SETTINGS = {
+export const CODE_SERVER_SETTINGS = {
 	// Overwritten at boot by the code-server-dark injection with the id this build actually
 	// ships; the legacy label only has to carry a code-server old enough to still use it.
 	'workbench.colorTheme': 'Default Dark Modern',
@@ -246,10 +246,20 @@ const terminalTask = (permissionMode: ClaudePermissionMode) => ({
 	problemMatcher: []
 });
 
+const CODE_SERVER_USER_DIR = '~/.local/share/code-server/User';
+
+/**
+ * Seeds the file only when it's missing. `relaunchSurface` re-runs this launcher *after* the
+ * injections have rewritten the theme id to the one the installed build uses, so an unconditional
+ * copy would put the stale staged id back and re-arm the very cache mismatch this all exists to
+ * avoid. A rebuild always gets a fresh container, so the staged defaults still land on every build.
+ * `[ -f ]` rather than `cp -n`, which busybox coreutils don't reliably carry.
+ */
 const CODE_SERVER_APPLY_SETTINGS =
-	`mkdir -p ~/.local/share/code-server/User && ` +
+	`mkdir -p ${CODE_SERVER_USER_DIR}; ` +
+	`[ -f ${CODE_SERVER_USER_DIR}/settings.json ] || ` +
 	`cp -f \\"$PWD/.devcontainer/${CODE_SERVER_SETTINGS_FILE}\\" ` +
-	`~/.local/share/code-server/User/settings.json 2>/dev/null;`;
+	`${CODE_SERVER_USER_DIR}/settings.json 2>/dev/null;`;
 
 // Fully detached (redirects + </dev/null + &) because `devcontainer up` waits for postStart's
 // pipes to close — an attached download would keep the whole boot on the Open VSX critical path.

--- a/src/lib/injections.server.ts
+++ b/src/lib/injections.server.ts
@@ -8,6 +8,7 @@ import { gitIdentity } from '../container-injections/git-identity.ts';
 import { claudeCodeCredentials } from '../container-injections/claude-code-credentials.ts';
 import { claudeCodeCustom } from '../container-injections/claude-code-custom.ts';
 import { claudeCodeIdeExtension } from '../container-injections/claude-code-ide-extension.ts';
+import { codeServerDark } from '../container-injections/code-server-dark.ts';
 import { claudeCodeInstall } from '../container-injections/claude-code-install.ts';
 import { claudeCodeUpdate } from '../container-injections/claude-code-update.ts';
 import { claudeCodeModels } from '../container-injections/claude-code-models.ts';
@@ -69,8 +70,9 @@ function buildStages(claudeInjection: Injection): Injection[][] {
 			claudeEffortLevel
 		],
 		// git-identity needs stage 1's safe.directory; ttyd shares the apt/dpkg lock with tmux and
-		// the /usr/local/bin symlink with claude-code-install, so it trails both.
-		[gitIdentity, attentionHooks, claudeCodeModels, ttyd, claudeCodeUpdate],
+		// the /usr/local/bin symlink with claude-code-install, so it trails both. code-server-dark
+		// drops the extension cache, so it must not run while stage 1 is still installing into it.
+		[gitIdentity, attentionHooks, claudeCodeModels, ttyd, claudeCodeUpdate, codeServerDark],
 		[githubCredentials, claudeStatusline, claudePermissionMode],
 		[claudeModel, claudeAliases],
 		// claude-trust edits ~/.claude.json, which the stage-1 Claude slot also writes.


### PR DESCRIPTION
## Problem

Two symptoms, neither reproducible on demand:

1. An IDE tab randomly **flips to light** and stays light until the user manually re-picks the theme inside that instance.
2. VS Code shows a **light flash on first load**, before the injected dark settings take effect.

#103 (`dbee251`) already pinned `workbench.colorTheme`, both `preferred*ColorTheme` keys, and disabled auto-detection. It did not fix either symptom.

## Root cause

This repo's devcontainer has code-server installed, so this is read out of the shipped bundle (`lib/vscode/out/vs/workbench/workbench.web.main.internal.js`, VS Code 1.131.0) rather than theorized. The workbench's startup theme resolution ends in:

```js
let U = this.settings.getPreferredColorScheme() ?? (Ot ? "light" : "dark");  // Ot === isWeb
b = a6.createUnloadedThemeForThemeType(U, w);
```

```js
getPreferredColorScheme(){
  if (getValue("window.autoDetectHighContrast") && hostColorService.highContrast) return ...;
  if (this.isDetectingColorScheme()) return hostColorService.dark ? "dark" : "light";  // gated on window.autoDetectColorScheme
}
```

`getPreferredColorScheme()` returns `undefined` when detection is off, so the expression falls through to a hardcoded `"light"` on web. **#103's `window.autoDetectColorScheme: false` gated off the only branch that could answer dark — it caused the flash it was meant to prevent.** The pinned `preferred*ColorTheme` pair was never consulted, because the whole preferred-scheme branch was switched off.

Two further contributors:

- **`prefers-color-scheme` inside the frame reported light.** `shell.html`'s `:root` declares `color-scheme: light dark` (auto) or `light`, and an embedded document's used color scheme is affected by its embedder (CSS Color Adjust §2.1; Blink `StyleEngine::ResolveColorSchemeForEmbedding`, Firefox ≥105).
- **The persisted theme cache was discarded every boot.** The bundle migrates `"Default Dark Modern"` → `"Dark Modern"` and rewrites user settings, but the launcher `cp -f`s the legacy label back on the next boot. The configured value then disagrees with the cached `settingsId`, and `b && I !== b.settingsId && (b = void 0)` drops the cache — straight back to the light fallback.

## Fix

Three layers, each closing a different path to light:

1. **`color-scheme: dark` on the IDE iframe** (`AppShell.svelte`) — pins the embedded document's scheme so the workbench's media query always reports dark, whatever theme Codebay itself is in. Client-side, so it reaches already-running instances on their next load.
2. **`window.autoDetectColorScheme` → `true`** (`devcontainer.server.ts`) — reverses that part of #103. Safe *only* because both preferred themes are the same dark theme, so even where the propagation in (1) doesn't hold (Safari), the light branch still resolves dark. `autoDetectHighContrast` stays off so the `hcLight` branch remains unreachable.
3. **New `code-server-dark` injection** — resolves the install root from the binary (no hardcoded `/usr/lib/code-server`), writes the theme label the installed build actually uses (`Dark 2026` on 1.131), and repoints every `uiTheme` of `vs`/`hc-light` in the bundled manifest at a dark theme, then drops `CachedExtensions`. Selecting by `uiTheme` rather than a `light*.json` glob is deliberate — the light set includes `2026-light` and `hc_light`, which a glob misses. After this, picking "Light Modern" renders dark.

Registered in stage 2, after `claude-code-ide-extension`, since that one installs into the extension cache this injection clears.

## Tests

`bun run checks` passes clean — 0 typecheck errors, 396 tests, 0 failures.

- New `code-server-dark` unit tests: manifest transform (light + high-contrast entries, idempotence, unrecognised shapes), label fallback chain, root resolution across both install layouts and when absent, and the health-check script.
- Dry-ran the transform against the real code-server on this box: 5 light entries repointed, idempotent, label resolves to `Dark 2026`.
- That dry run caught a bug in review — the shipped manifest is **minified** (`"uiTheme":"vs"`, no space), so the first health-check grep would have silently reported green on an unpatched install. The pattern is now whitespace-tolerant, with a test pinning the minified case.
- `devcontainer.isolated.test.ts` theme test updated for the flipped flag, and now also asserts `workbench.colorTheme`.
- `WRITES` clobber-safety map updated.

## Not verified

**No Docker daemon is available in this devcontainer**, so none of the live boot checks ran: first-paint darkness, the in-frame `matchMedia('(prefers-color-scheme: dark)')` assertion with Codebay in light mode, picking "Light Modern" inside an instance, or tab-switching between two instances. `apply()`/`check()` have only been exercised against stubs and against this box's real code-server files — never against a booted container. Worth a manual pass on a machine with a daemon before merging.

## Notes

- Layer 2 deliberately reverses #103, so the comment in `devcontainer.server.ts` carries the reason — a future reader will otherwise assume it's the bug.
- Layer 3 mutates code-server's vendored VS Code tree. It's idempotent and always non-fatal: an unrecognised layout degrades to "layers 1+2 only" rather than a failed boot.
- Existing instances get layer 1 only until rebuilt.
- Residual, not addressed: all same-origin workbenches share one IndexedDB blob (`vscode-web-state-db-global` → `colorThemeData`) plus a same-named `BroadcastChannel`; code-server's `unique-db.diff` path-scopes only *workspace* storage. Harmless once every instance resolves dark, and isolating it would mean giving each instance its own origin, which would break the same-origin proxy the keyboard shortcuts rely on.
