### PR TITLE
Redraw crown avatar by hand

### DIFF
--- a/src/avatars/crown.ts
+++ b/src/avatars/crown.ts
@@ -2,11 +2,10 @@ import type { AvatarArt } from './types.ts';
 
 const art: AvatarArt = {
 	name: 'crown',
-	robot: true,
 	pixels: [
 		'#......#',
-		'#..##..#',
-		'##.##.##',
+		'#..#...#',
+		'##.#..##',
 		'##.##.##',
 		'########',
 		'#.#.#.#.',


### PR DESCRIPTION
Closes #154

Replaces the AI-generated `crown` placeholder with a hand-drawn sprite (drops the `robot` flag).

Landed from the in-app avatar-editor easter egg via the avatar-contribution-pr skill.