### PR TITLE
Redraw key avatar by hand

### DIFF
--- a/src/avatars/key.ts
+++ b/src/avatars/key.ts
@@ -2,16 +2,15 @@ import type { AvatarArt } from './types.ts';
 
 const art: AvatarArt = {
 	name: 'key',
-	robot: true,
 	pixels: [
 		'.####...',
-		'##..##..',
 		'##..##..',
 		'##..##..',
 		'.####...',
 		'..##....',
 		'..####..',
-		'..##.##.'
+		'..##....',
+		'..####..'
 	]
 };
 


### PR DESCRIPTION
Closes #161

Replaces the AI-generated `key` placeholder with a hand-drawn sprite (drops the `robot` flag).

Landed from the in-app avatar-editor easter egg via the avatar-contribution-pr skill.