### PR TITLE
Redraw anchor avatar by hand

### DIFF
--- a/src/avatars/anchor.ts
+++ b/src/avatars/anchor.ts
@@ -2,13 +2,12 @@ import type { AvatarArt } from './types.ts';
 
 const art: AvatarArt = {
 	name: 'anchor',
-	robot: true,
 	pixels: [
 		'...##...',
 		'..#..#..',
-		'..#..#..',
 		'.######.',
 		'...##...',
+		'..####..',
 		'#..##..#',
 		'########',
 		'.######.'


### PR DESCRIPTION
Closes #164

Replaces the AI-generated `anchor` placeholder with a hand-drawn sprite (drops the `robot` flag).

Landed from the in-app avatar-editor easter egg via the avatar-contribution-pr skill.