### PR TITLE
Redraw bear avatar by hand

### DIFF
--- a/src/avatars/bear.ts
+++ b/src/avatars/bear.ts
@@ -2,13 +2,12 @@ import type { AvatarArt } from './types.ts';
 
 const art: AvatarArt = {
 	name: 'bear',
-	robot: true,
 	pixels: [
-		'##....##',
+		'###..###',
 		'###..###',
 		'########',
-		'##.##.##',
 		'########',
+		'##.##.##',
 		'########',
 		'###..###',
 		'.######.'


### PR DESCRIPTION
Closes #165

Replaces the AI-generated `bear` placeholder with a hand-drawn sprite (drops the `robot` flag).

Landed from the in-app avatar-editor easter egg via the avatar-contribution-pr skill.