### PR TITLE
Redraw rabbit avatar by hand

### DIFF
--- a/src/avatars/rabbit.ts
+++ b/src/avatars/rabbit.ts
@@ -2,16 +2,15 @@ import type { AvatarArt } from './types.ts';
 
 const art: AvatarArt = {
 	name: 'rabbit',
-	robot: true,
 	pixels: [
 		'.#....#.',
 		'.##..##.',
 		'.##..##.',
 		'..####..',
-		'.######.',
+		'.#.##.#.',
+		'########',
 		'###..###',
-		'#..##..#',
-		'.######.'
+		'.#.##.#.'
 	]
 };
 


### PR DESCRIPTION
Closes #169

Replaces the AI-generated `rabbit` placeholder with a hand-drawn sprite (drops the `robot` flag).

Landed from the in-app avatar-editor easter egg via the avatar-contribution-pr skill.