### PR TITLE
feat: add Claude output style setting

### DIFF
--- a/src/components/SettingsView.svelte
+++ b/src/components/SettingsView.svelte
@@ -42,14 +42,17 @@
 	import {
 		CLAUDE_PERMISSION_MODES,
 		CLAUDE_EFFORT_LEVELS,
+		CLAUDE_OUTPUT_STYLES,
 		type ClaudePermissionMode,
 		type ClaudeEffortLevel,
+		type ClaudeOutputStyle,
 		type InstanceMode
 	} from '../types.ts';
 	import Terminal from '@lucide/svelte/icons/terminal';
 	import LayoutTemplate from '@lucide/svelte/icons/layout-template';
 	import ShieldCheck from '@lucide/svelte/icons/shield-check';
 	import Gauge from '@lucide/svelte/icons/gauge';
+	import MessageSquare from '@lucide/svelte/icons/message-square';
 	import { installPopupBackTrap } from '../lib/popup-nav.ts';
 
 	/** Every settings form action fails with the same `{ error }` shape. */
@@ -60,6 +63,7 @@
 		defaultMode,
 		claudePermissionMode,
 		claudeEffortLevel,
+		claudeOutputStyle,
 		defaultImage,
 		builtinImage,
 		disableBuildCache,
@@ -100,6 +104,7 @@
 		defaultMode: InstanceMode;
 		claudePermissionMode: ClaudePermissionMode;
 		claudeEffortLevel: ClaudeEffortLevel;
+		claudeOutputStyle: ClaudeOutputStyle;
 		defaultImage: string;
 		builtinImage: string;
 		disableBuildCache: boolean;
@@ -290,6 +295,33 @@
 		if (next === effortChoice) return;
 		flushSync(() => (effortChoice = next));
 		effortFormEl?.requestSubmit();
+	}
+
+	// svelte-ignore state_referenced_locally
+	let outputStyleChoice = $state<ClaudeOutputStyle>(claudeOutputStyle);
+	let savingOutputStyle = $state(false);
+	let outputStyleError = $state<string | null>(null);
+	let outputStyleFormEl: HTMLFormElement | undefined;
+
+	const outputStyleOpts = saveOpts<{ style: ClaudeOutputStyle }>({
+		setSaving: (v) => (savingOutputStyle = v),
+		setError: (v) => (outputStyleError = v),
+		setMsg: () => {},
+		onSuccess: (data) => {
+			if (data?.style) outputStyleChoice = data.style;
+		}
+	});
+
+	const OUTPUT_STYLE_LABELS: Record<ClaudeOutputStyle, string> = {
+		default: 'Default',
+		none: 'None',
+		Concise: 'Concise'
+	};
+
+	function chooseOutputStyle(next: ClaudeOutputStyle) {
+		if (next === outputStyleChoice) return;
+		flushSync(() => (outputStyleChoice = next));
+		outputStyleFormEl?.requestSubmit();
 	}
 
 	// svelte-ignore state_referenced_locally
@@ -970,6 +1002,48 @@
 			</form>
 			{#if effortError}
 				<div class="sub"><div class="msg error">{effortError}</div></div>
+			{/if}
+		</section>
+
+		<section class="card">
+			<form
+				class="row"
+				method="POST"
+				action="?/claudeOutputStyle"
+				bind:this={outputStyleFormEl}
+				{@attach enhance(outputStyleOpts)}
+			>
+				<div class="label">
+					<MessageSquare size={20} />
+					<div class="text">
+						<div class="name">Claude output style</div>
+						<div class="desc">
+							The output style Claude Code starts new sessions in, written to
+							<code>~/.claude/settings.json</code>. <strong>Default</strong> inherits your host
+							<code>~/.claude/settings.json</code> (including any custom styles);
+							<strong>None</strong>
+							forces it off. Applies on create and rebuild, not to already-running instances.
+						</div>
+					</div>
+				</div>
+				<input type="hidden" name="style" value={outputStyleChoice} />
+				<div class="mode-toggle" role="group" aria-label="Claude output style">
+					{#each CLAUDE_OUTPUT_STYLES as option (option)}
+						<button
+							type="button"
+							class="mode-btn"
+							class:active={outputStyleChoice === option}
+							aria-pressed={outputStyleChoice === option}
+							disabled={savingOutputStyle}
+							onclick={() => chooseOutputStyle(option)}
+						>
+							{OUTPUT_STYLE_LABELS[option]}
+						</button>
+					{/each}
+				</div>
+			</form>
+			{#if outputStyleError}
+				<div class="sub"><div class="msg error">{outputStyleError}</div></div>
 			{/if}
 		</section>
 

--- a/src/container-injections/claude-output-style.ts
+++ b/src/container-injections/claude-output-style.ts
@@ -1,0 +1,84 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { getOption } from '../lib/db.server.ts';
+import { writeContainerFile } from '../lib/container-files.server.ts';
+import {
+	claudeConfigFile,
+	mergeClaudeSettings,
+	readClaudeSettings
+} from '../lib/claude-settings.server.ts';
+import { readHostClaudeSettings } from './claude-statusline.ts';
+import { normalizeOutputStyle } from '../types.ts';
+import type { ClaudeOutputStyle } from '../types.ts';
+import type { ContainerTarget, Injection } from '../lib/injections.server.ts';
+
+/** Also read by the settings-page `serverProps` to seed the UI. */
+export function getClaudeOutputStyle(): ClaudeOutputStyle {
+	return normalizeOutputStyle(getOption('claude_output_style'));
+}
+
+/** The `outputStyle` actually applied: the setting itself, the host's value when inheriting, or null. */
+export async function resolveEffectiveOutputStyle(): Promise<string | null> {
+	const setting = getClaudeOutputStyle();
+	if (setting === 'none') return null;
+	if (setting !== 'default') return setting;
+	const style = (await readHostClaudeSettings())?.outputStyle;
+	return typeof style === 'string' && style.trim() ? style.trim() : null;
+}
+
+/** The host's custom output-style definitions, so a non-built-in name resolves inside the container. */
+export async function readHostOutputStyleFiles(): Promise<{ name: string; content: string }[]> {
+	const dir = join(homedir(), '.claude', 'output-styles');
+	let names: string[];
+	try {
+		names = (await readdir(dir)).filter((n) => n.endsWith('.md'));
+	} catch {
+		return [];
+	}
+	const files = await Promise.all(
+		names.map(async (name) => {
+			try {
+				return { name, content: await readFile(join(dir, name), 'utf8') };
+			} catch {
+				return null;
+			}
+		})
+	);
+	return files.filter((f): f is { name: string; content: string } => f !== null);
+}
+
+/** Writes Claude Code's `outputStyle` default into the container, mirroring host custom-style files. */
+export const claudeOutputStyle: Injection = {
+	id: 'claude-output-style',
+	label: 'output style',
+
+	async apply(target: ContainerTarget, log) {
+		const style = await resolveEffectiveOutputStyle();
+		if (!style) {
+			log('No Claude output style to apply; skipped\n');
+			return;
+		}
+		for (const file of await readHostOutputStyleFiles()) {
+			await writeContainerFile(
+				target,
+				claudeConfigFile(`output-styles/${file.name}`, '644'),
+				file.content
+			);
+		}
+		log(`Setting Claude output style (${style})…\n`);
+		const result = await mergeClaudeSettings(target, { outputStyle: style });
+		log(
+			result.ok
+				? '✓ Claude output style configured in container\n'
+				: `⚠ Claude output style injection failed: ${result.error}\n`
+		);
+	},
+
+	async check(target) {
+		const expected = await resolveEffectiveOutputStyle();
+		const settings = await readClaudeSettings(target);
+		const actual = settings?.outputStyle;
+		return expected === null ? actual == null : actual === expected;
+	}
+};

--- a/src/container-injections/injections.isolated.test.ts
+++ b/src/container-injections/injections.isolated.test.ts
@@ -14,6 +14,7 @@ import { hostEnvVarPresence, hostEnvVarsConfig, parseHostEnvVarNames } from './h
 import { customEnvVarsConfig, customEnvVarValues, parseCustomEnvVars } from './custom-env-vars.ts';
 import { expandTilde, extractScriptPath } from './claude-statusline.ts';
 import { hostClaudeModel } from './claude-model.ts';
+import { getClaudeOutputStyle, resolveEffectiveOutputStyle } from './claude-output-style.ts';
 import { NO_COAUTHOR_SETTINGS } from './claude-no-coauthor.ts';
 import { claudeTrustConfig, CLAUDE_TRUST_SETTINGS } from './claude-trust.ts';
 import { homedir } from 'node:os';
@@ -123,6 +124,14 @@ describe('injection registry', () => {
 		expect(typeof effort!.check).toBe('function');
 	});
 
+	test('claude-output-style is registered with a health check and no auth chip', () => {
+		const outputStyle = injections.find((i) => i.id === 'claude-output-style');
+		expect(outputStyle).toBeDefined();
+		// Inherits the host default (or the app option); none is a valid outcome, so no chip.
+		expect(outputStyle!.auth).toBeUndefined();
+		expect(typeof outputStyle!.check).toBe('function');
+	});
+
 	test('host-env-vars is registered with a health check and no auth chip', () => {
 		const hostEnvVars = injections.find((i) => i.id === 'host-env-vars');
 		expect(hostEnvVars).toBeDefined();
@@ -204,6 +213,7 @@ describe('resolveInjectionStages — clobber safety', () => {
 		'claude-trust': ['claude-json', 'settings-json'],
 		'claude-aliases': ['rc'],
 		'claude-no-coauthor': ['settings-json'],
+		'claude-output-style': ['settings-json', 'output-styles-dir'],
 		'host-env-vars': ['host-env-file', 'rc'],
 		// Writes nothing to the container — values ride containerEnv, so it can share any stage.
 		'custom-env-vars': []
@@ -251,6 +261,7 @@ describe('resolveInjectionStages — clobber safety', () => {
 		expect(at.get('claude-statusline')!).toBeLessThan(at.get('claude-model')!);
 		expect(at.get('claude-model')!).toBeLessThan(at.get('claude-trust')!);
 		expect(at.get('claude-trust')!).toBeLessThan(at.get('claude-no-coauthor')!);
+		expect(at.get('claude-no-coauthor')!).toBeLessThan(at.get('claude-output-style')!);
 		// rc-file append chain.
 		expect(at.get('claude-code-models')!).toBeLessThan(at.get('claude-permission-mode')!);
 		expect(at.get('claude-permission-mode')!).toBeLessThan(at.get('claude-aliases')!);
@@ -878,6 +889,30 @@ describe('hostClaudeModel', () => {
 	test('is null when LiteLLM owns the model', async () => {
 		setOption('custom_endpoint_enabled', '1');
 		expect(await hostClaudeModel()).toBeNull();
+	});
+});
+
+describe('claude output style', () => {
+	afterEach(() => setOption('claude_output_style', 'default'));
+
+	test('getClaudeOutputStyle normalizes unknown values to inherit-from-host', () => {
+		setOption('claude_output_style', 'bogus');
+		expect(getClaudeOutputStyle()).toBe('default');
+	});
+
+	test('getClaudeOutputStyle returns the stored enum value', () => {
+		setOption('claude_output_style', 'Concise');
+		expect(getClaudeOutputStyle()).toBe('Concise');
+	});
+
+	test('none forces the style off (no value applied)', async () => {
+		setOption('claude_output_style', 'none');
+		expect(await resolveEffectiveOutputStyle()).toBeNull();
+	});
+
+	test('an explicit style is applied verbatim, without reading the host', async () => {
+		setOption('claude_output_style', 'Concise');
+		expect(await resolveEffectiveOutputStyle()).toBe('Concise');
 	});
 });
 

--- a/src/lib/injections.server.ts
+++ b/src/lib/injections.server.ts
@@ -17,6 +17,7 @@ import { attentionHooks } from '../container-injections/attention-hooks.ts';
 import { claudeStatusline } from '../container-injections/claude-statusline.ts';
 import { claudeModel } from '../container-injections/claude-model.ts';
 import { claudeEffortLevel } from '../container-injections/claude-effort-level.ts';
+import { claudeOutputStyle } from '../container-injections/claude-output-style.ts';
 import { claudePermissionMode } from '../container-injections/claude-permission-mode.ts';
 import { claudeTrust } from '../container-injections/claude-trust.ts';
 import { claudeAliases } from '../container-injections/claude-aliases.ts';
@@ -78,7 +79,10 @@ function buildStages(claudeInjection: Injection): Injection[][] {
 		// claude-trust edits ~/.claude.json, which the stage-1 Claude slot also writes.
 		// custom-env-vars writes nothing (values ride containerEnv) — it only verifies + health-checks.
 		[claudeTrust, hostEnvVars, customEnvVars],
-		[claudeNoCoauthor]
+		[claudeNoCoauthor],
+		// A settings.json writer of its own: every other stage already has one, and same-stage
+		// settings.json writers race — so output style merges last, on its own.
+		[claudeOutputStyle]
 	];
 }
 

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -3,13 +3,19 @@
 	import '@fontsource-variable/jetbrains-mono';
 	import SettingsView from '../components/SettingsView.svelte';
 	import type { AvatarArt } from '../avatars/index.ts';
-	import type { ClaudeEffortLevel, ClaudePermissionMode, InstanceMode } from '../types.ts';
+	import type {
+		ClaudeEffortLevel,
+		ClaudeOutputStyle,
+		ClaudePermissionMode,
+		InstanceMode
+	} from '../types.ts';
 
 	let {
 		pet,
 		defaultMode,
 		claudePermissionMode,
 		claudeEffortLevel,
+		claudeOutputStyle,
 		defaultImage,
 		builtinImage,
 		disableBuildCache,
@@ -50,6 +56,7 @@
 		defaultMode: InstanceMode;
 		claudePermissionMode: ClaudePermissionMode;
 		claudeEffortLevel: ClaudeEffortLevel;
+		claudeOutputStyle: ClaudeOutputStyle;
 		defaultImage: string;
 		builtinImage: string;
 		disableBuildCache: boolean;
@@ -93,6 +100,7 @@
 	{defaultMode}
 	{claudePermissionMode}
 	{claudeEffortLevel}
+	{claudeOutputStyle}
 	{defaultImage}
 	{builtinImage}
 	{disableBuildCache}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -27,6 +27,7 @@ import {
 } from './container-injections/claude-code-update.ts';
 import { getClaudePermissionMode } from './container-injections/claude-permission-mode.ts';
 import { getClaudeEffortLevel } from './container-injections/claude-effort-level.ts';
+import { getClaudeOutputStyle } from './container-injections/claude-output-style.ts';
 import { browse } from './lib/picker.server.ts';
 import { pickNamePrompt } from './avatars/name-prompts.ts';
 import { avatars, findAvatar } from './avatars/index.ts';
@@ -73,6 +74,7 @@ import {
 	normalizeMode,
 	normalizePermissionMode,
 	normalizeEffortLevel,
+	normalizeOutputStyle,
 	type InstanceFilter
 } from './types.ts';
 
@@ -205,6 +207,7 @@ export const routes: Record<string, MochiRouteValue> = {
 				defaultMode: getDefaultMode(),
 				claudePermissionMode: getClaudePermissionMode(),
 				claudeEffortLevel: getClaudeEffortLevel(),
+				claudeOutputStyle: getClaudeOutputStyle(),
 				defaultImage: getOption('default_image') ?? DEFAULT_IMAGE,
 				builtinImage: DEFAULT_IMAGE,
 				disableBuildCache: getOption('disable_build_cache') === '1',
@@ -275,6 +278,13 @@ export const routes: Record<string, MochiRouteValue> = {
 				const level = normalizeEffortLevel(str(formData, 'level'));
 				setOption('claude_effort_level', level);
 				return success({ level });
+			},
+
+			// Injected into ~/.claude/settings.json at provision time, so it lands on create/rebuild.
+			claudeOutputStyle: ({ formData }) => {
+				const style = normalizeOutputStyle(str(formData, 'style'));
+				setOption('claude_output_style', style);
+				return success({ style });
 			},
 
 			// Persist the default container image used when a source folder ships no devcontainer.json.

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,22 @@ export function normalizeEffortLevel(value: unknown): ClaudeEffortLevel {
 		: 'high';
 }
 
+/**
+ * Claude Code's output style for new sessions, written to `settings.json` as `outputStyle`.
+ * `'default'` inherits whatever the host has; `'none'` forces it off; anything else is a literal
+ * Claude output-style name — append future built-ins (`'Explanatory'`, `'Learning'`, …) here.
+ */
+export type ClaudeOutputStyle = 'default' | 'none' | 'Concise';
+
+export const CLAUDE_OUTPUT_STYLES: ClaudeOutputStyle[] = ['default', 'none', 'Concise'];
+
+/** Anything unrecognised falls back to inheriting the host's output style. */
+export function normalizeOutputStyle(value: unknown): ClaudeOutputStyle {
+	return CLAUDE_OUTPUT_STYLES.includes(value as ClaudeOutputStyle)
+		? (value as ClaudeOutputStyle)
+		: 'default';
+}
+
 /** Dashboard run-state view filter: All | Active (running/creating) | Stopped (stopped/error). */
 export type InstanceFilter = 'all' | 'active' | 'stopped';
 


### PR DESCRIPTION
## What

Adds support for **Claude output styles**. A new **Output style** control in `/config` (the `/settings` page) writes Claude Code's `outputStyle` into each instance's `~/.claude/settings.json` at provision time, so new instances start in the chosen style.

Toggle: **`Default | None | Concise`** (segmented buttons, matching the permission-mode / effort-level pattern).

- **Default** (the default) — inherits whatever `outputStyle` is in the host's `~/.claude/settings.json`; nothing written if the host has none. Also mirrors the host's `~/.claude/output-styles/*.md` into the container so **custom** (non-built-in) styles resolve end-to-end.
- **None** — forces the style off.
- **Concise** — forces Concise.

The enum (`CLAUDE_OUTPUT_STYLES` in `src/types.ts`) is structured so more built-in styles (`Explanatory`, `Learning`, …) can be appended later.

## How

Follows the existing `claude-effort-level` injection template (an `options`-driven enum merged into `settings.json` via `mergeClaudeSettings`), and reuses `readHostClaudeSettings()` for the inherit-from-host default.

- `src/types.ts` — `ClaudeOutputStyle` type, `CLAUDE_OUTPUT_STYLES`, `normalizeOutputStyle`.
- `src/container-injections/claude-output-style.ts` (new) — the `Injection`: resolves the effective style, mirrors host custom-style files, merges `{ outputStyle }`, and a `check()` health row.
- `src/lib/injections.server.ts` — registered as a **new trailing stage** (every existing stage already has one `settings.json` writer, and same-stage writers would race).
- `src/routes.ts` — `serverProps` seed + `claudeOutputStyle` action.
- `src/pages/Settings.svelte`, `src/components/SettingsView.svelte` — the prop plumbing + the segmented-toggle card.

## Testing

- `bun run checks` passes (format + eslint + typecheck + 404 tests).
- New isolated tests: registration, clobber-safety `WRITES` entry, settings.json ordering assertion, and resolution unit tests (`none` → off, explicit style → verbatim, normalization).
- UI smoke test against the dev server: the card renders `Default | None | Concise`, and the `?/claudeOutputStyle` POST persists (reload keeps the choice).
- Live container boot not verified — Docker is unavailable in the Bun-only devcontainer.