### PR TITLE
docs: embed YouTube demo video on marketing site

### DIFF
--- a/marketing/index.html
+++ b/marketing/index.html
@@ -101,7 +101,7 @@
 					<div class="demo-frame panel">
 						<div class="panel-bar">
 							<span class="panel-bar-dots"><span></span><span></span><span></span></span>
-							<span>Codebay — Live Demo</span>
+							<span>The five minute demo</span>
 							<span class="panel-bar-dots spacer" aria-hidden="true"
 								><span></span><span></span><span></span
 							></span>
@@ -109,7 +109,7 @@
 						<div class="demo-screen">
 							<iframe
 								src="https://www.youtube-nocookie.com/embed/-wUJ12ISWmc"
-								title="Codebay — Live Demo"
+								title="The five minute demo of Codebay"
 								loading="lazy"
 								allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
 								allowfullscreen

--- a/marketing/index.html
+++ b/marketing/index.html
@@ -107,9 +107,13 @@
 							></span>
 						</div>
 						<div class="demo-screen">
-							<video autoplay muted loop playsinline poster="./assets/demo-poster.svg">
-								<source src="./assets/demo.mp4" type="video/mp4" />
-							</video>
+							<iframe
+								src="https://www.youtube-nocookie.com/embed/-wUJ12ISWmc"
+								title="Codebay — Live Demo"
+								loading="lazy"
+								allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+								allowfullscreen
+							></iframe>
 						</div>
 					</div>
 

--- a/marketing/index.html
+++ b/marketing/index.html
@@ -111,7 +111,15 @@
 								src="https://www.youtube-nocookie.com/embed/-wUJ12ISWmc"
 								title="The five minute demo of Codebay"
 								loading="lazy"
-								allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+								allow="
+									accelerometer;
+									autoplay;
+									clipboard-write;
+									encrypted-media;
+									gyroscope;
+									picture-in-picture;
+									web-share;
+								"
 								allowfullscreen
 							></iframe>
 						</div>

--- a/marketing/styles.css
+++ b/marketing/styles.css
@@ -415,12 +415,14 @@ h1.headline {
 	background: #0d0e0a center / cover no-repeat url('./assets/demo-poster.svg');
 	overflow: hidden;
 }
-.demo-screen video {
+.demo-screen video,
+.demo-screen iframe {
 	position: absolute;
 	inset: 0;
 	width: 100%;
 	height: 100%;
 	object-fit: cover;
+	border: 0;
 }
 
 .cta-row {


### PR DESCRIPTION
Replaces the dead `demo.mp4` `<video>` in the marketing hero with a YouTube embed of the recorded demo (`-wUJ12ISWmc`, privacy-enhanced `youtube-nocookie.com`, lazy-loaded). Broadens the `.demo-screen` fill rule to cover the iframe.

Merging to `main` triggers `deploy-marketing.yml` and publishes to GitHub Pages.