### PR TITLE
feat: add Codebay logo as favicon on the control panel

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+	<rect x="0" y="0" width="24" height="24" fill="#14150f" />
+	<g fill="none" stroke="#d7d8d2" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+		<path d="M11 21.73a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73z" />
+		<path d="M12 22V12" />
+		<polyline points="3.29 7 12 12 20.71 7" />
+		<path d="m7.5 4.27 9 5.15" />
+	</g>
+</svg>

--- a/src/shell.html
+++ b/src/shell.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<title>Codebay</title>
 		<style>
 			/* Each themed variable is defined once as light-dark(light, dark). With no


### PR DESCRIPTION
## What

Adds the Codebay logo as the browser-tab favicon for the control panel. Previously `src/shell.html` had no `<link rel="icon">`, so the tab showed a blank/default icon.

## Changes

- **`public/favicon.svg`** — the Codebay package-cube mark (the same logo used on the marketing site and by the app's `Brand.svelte` header icon). Mochi serves `public/` from disk, so it's reachable at `/favicon.svg`, and `public` is already in `package.json`'s `files` list, so it ships in the `bunx codebay` tarball.
- **`src/shell.html`** — added `<link rel="icon" type="image/svg+xml" href="/favicon.svg" />` to `<head>`, so every SSR'd page (dashboard, IDE, settings) picks it up.

A static SVG (matching the wordmark's box logo) is used rather than the per-instance pet avatar, so the tab icon stays stable regardless of the "Pet logo" setting.

## Checks

`bun run checks` passes (406 tests, 0 failures).