### PR TITLE
fix(marketing): sync avatar carousel with current sprites

### DIFF
--- a/marketing/index.html
+++ b/marketing/index.html
@@ -588,10 +588,9 @@
 									<rect x="3" y="0" width="2" height="1" />
 									<rect x="2" y="1" width="1" height="1" />
 									<rect x="5" y="1" width="1" height="1" />
-									<rect x="2" y="2" width="1" height="1" />
-									<rect x="5" y="2" width="1" height="1" />
-									<rect x="1" y="3" width="6" height="1" />
-									<rect x="3" y="4" width="2" height="1" />
+									<rect x="1" y="2" width="6" height="1" />
+									<rect x="3" y="3" width="2" height="1" />
+									<rect x="2" y="4" width="4" height="1" />
 									<rect x="0" y="5" width="1" height="1" />
 									<rect x="3" y="5" width="2" height="1" />
 									<rect x="7" y="5" width="1" height="1" />
@@ -608,18 +607,24 @@
 									role="img"
 									aria-label="bee pixel avatar"
 								>
-									<rect x="1" y="0" width="1" height="1" />
-									<rect x="6" y="0" width="1" height="1" />
-									<rect x="0" y="1" width="2" height="1" />
-									<rect x="3" y="1" width="2" height="1" />
-									<rect x="6" y="1" width="2" height="1" />
-									<rect x="0" y="2" width="1" height="1" />
-									<rect x="2" y="2" width="4" height="1" />
-									<rect x="7" y="2" width="1" height="1" />
-									<rect x="1" y="3" width="6" height="1" />
-									<rect x="1" y="4" width="6" height="1" />
-									<rect x="1" y="6" width="6" height="1" />
-									<rect x="2" y="7" width="4" height="1" />
+									<rect class="gray" x="3" y="1" width="2" height="1" />
+									<rect x="5" y="1" width="2" height="1" />
+									<rect class="gray" x="2" y="2" width="2" height="1" />
+									<rect x="4" y="2" width="3" height="1" />
+									<rect class="gray" x="3" y="3" width="1" height="1" />
+									<rect x="4" y="3" width="1" height="1" />
+									<rect x="1" y="4" width="5" height="1" />
+									<rect x="0" y="5" width="1" height="1" />
+									<rect class="gray" x="2" y="5" width="1" height="1" />
+									<rect x="3" y="5" width="1" height="1" />
+									<rect class="gray" x="4" y="5" width="1" height="1" />
+									<rect x="5" y="5" width="3" height="1" />
+									<rect x="0" y="6" width="2" height="1" />
+									<rect class="gray" x="2" y="6" width="1" height="1" />
+									<rect x="3" y="6" width="1" height="1" />
+									<rect class="gray" x="4" y="6" width="1" height="1" />
+									<rect x="5" y="6" width="2" height="1" />
+									<rect x="1" y="7" width="5" height="1" />
 								</svg>
 								<figcaption>bee</figcaption>
 							</figure>
@@ -654,21 +659,22 @@
 									role="img"
 									aria-label="owl pixel avatar"
 								>
-									<rect x="0" y="0" width="1" height="1" />
-									<rect x="7" y="0" width="1" height="1" />
-									<rect x="0" y="1" width="2" height="1" />
-									<rect x="6" y="1" width="2" height="1" />
-									<rect x="1" y="2" width="6" height="1" />
-									<rect x="1" y="3" width="1" height="1" />
+									<rect x="1" y="0" width="1" height="1" />
+									<rect x="6" y="0" width="1" height="1" />
+									<rect x="0" y="1" width="1" height="1" />
+									<rect x="7" y="1" width="1" height="1" />
+									<rect x="0" y="2" width="8" height="1" />
+									<rect x="0" y="3" width="1" height="1" />
 									<rect x="3" y="3" width="2" height="1" />
-									<rect x="6" y="3" width="1" height="1" />
-									<rect x="1" y="4" width="1" height="1" />
+									<rect x="7" y="3" width="1" height="1" />
+									<rect x="0" y="4" width="1" height="1" />
 									<rect x="3" y="4" width="2" height="1" />
-									<rect x="6" y="4" width="1" height="1" />
-									<rect x="1" y="5" width="6" height="1" />
-									<rect x="1" y="6" width="6" height="1" />
-									<rect x="2" y="7" width="1" height="1" />
-									<rect x="5" y="7" width="1" height="1" />
+									<rect x="7" y="4" width="1" height="1" />
+									<rect x="0" y="5" width="8" height="1" />
+									<rect x="0" y="6" width="3" height="1" />
+									<rect x="5" y="6" width="3" height="1" />
+									<rect x="1" y="7" width="3" height="1" />
+									<rect x="5" y="7" width="2" height="1" />
 								</svg>
 								<figcaption>owl</figcaption>
 							</figure>
@@ -680,17 +686,19 @@
 									role="img"
 									aria-label="fox pixel avatar"
 								>
-									<rect x="0" y="0" width="2" height="1" />
-									<rect x="6" y="0" width="2" height="1" />
+									<rect x="0" y="0" width="1" height="1" />
+									<rect class="gray" x="4" y="0" width="1" height="1" />
 									<rect x="0" y="1" width="2" height="1" />
-									<rect x="6" y="1" width="2" height="1" />
-									<rect x="0" y="2" width="8" height="1" />
-									<rect x="0" y="3" width="3" height="1" />
-									<rect x="5" y="3" width="3" height="1" />
-									<rect x="0" y="4" width="8" height="1" />
-									<rect x="0" y="5" width="8" height="1" />
-									<rect x="1" y="6" width="6" height="1" />
-									<rect x="2" y="7" width="4" height="1" />
+									<rect class="gray" x="3" y="1" width="2" height="1" />
+									<rect x="0" y="2" width="3" height="1" />
+									<rect class="gray" x="3" y="2" width="2" height="1" />
+									<rect x="0" y="3" width="5" height="1" />
+									<rect x="7" y="3" width="1" height="1" />
+									<rect x="0" y="4" width="2" height="1" />
+									<rect x="3" y="4" width="5" height="1" />
+									<rect x="0" y="5" width="7" height="1" />
+									<rect x="0" y="6" width="6" height="1" />
+									<rect x="0" y="7" width="5" height="1" />
 								</svg>
 								<figcaption>fox</figcaption>
 							</figure>
@@ -702,18 +710,19 @@
 									role="img"
 									aria-label="robot pixel avatar"
 								>
-									<rect x="3" y="0" width="2" height="1" />
-									<rect x="3" y="1" width="1" height="1" />
-									<rect x="1" y="2" width="6" height="1" />
-									<rect x="0" y="3" width="1" height="1" />
-									<rect x="2" y="3" width="4" height="1" />
-									<rect x="7" y="3" width="1" height="1" />
+									<rect x="1" y="0" width="6" height="1" />
+									<rect x="3" y="1" width="2" height="1" />
+									<rect x="0" y="2" width="8" height="1" />
+									<rect x="0" y="3" width="8" height="1" />
 									<rect x="0" y="4" width="1" height="1" />
-									<rect x="3" y="4" width="2" height="1" />
+									<rect x="2" y="4" width="4" height="1" />
 									<rect x="7" y="4" width="1" height="1" />
-									<rect x="1" y="5" width="6" height="1" />
-									<rect x="1" y="6" width="5" height="1" />
-									<rect x="1" y="7" width="6" height="1" />
+									<rect x="0" y="5" width="1" height="1" />
+									<rect x="2" y="5" width="4" height="1" />
+									<rect x="7" y="5" width="1" height="1" />
+									<rect x="0" y="6" width="3" height="1" />
+									<rect x="5" y="6" width="3" height="1" />
+									<rect x="0" y="7" width="8" height="1" />
 								</svg>
 								<figcaption>robot</figcaption>
 							</figure>
@@ -728,10 +737,10 @@
 									<rect x="0" y="0" width="1" height="1" />
 									<rect x="7" y="0" width="1" height="1" />
 									<rect x="0" y="1" width="1" height="1" />
-									<rect x="3" y="1" width="2" height="1" />
+									<rect x="3" y="1" width="1" height="1" />
 									<rect x="7" y="1" width="1" height="1" />
 									<rect x="0" y="2" width="2" height="1" />
-									<rect x="3" y="2" width="2" height="1" />
+									<rect x="3" y="2" width="1" height="1" />
 									<rect x="6" y="2" width="2" height="1" />
 									<rect x="0" y="3" width="2" height="1" />
 									<rect x="3" y="3" width="2" height="1" />
@@ -759,13 +768,11 @@
 									<rect x="4" y="1" width="2" height="1" />
 									<rect x="0" y="2" width="2" height="1" />
 									<rect x="4" y="2" width="2" height="1" />
-									<rect x="0" y="3" width="2" height="1" />
-									<rect x="4" y="3" width="2" height="1" />
-									<rect x="1" y="4" width="4" height="1" />
-									<rect x="2" y="5" width="2" height="1" />
-									<rect x="2" y="6" width="4" height="1" />
-									<rect x="2" y="7" width="2" height="1" />
-									<rect x="5" y="7" width="2" height="1" />
+									<rect x="1" y="3" width="4" height="1" />
+									<rect x="2" y="4" width="2" height="1" />
+									<rect x="2" y="5" width="4" height="1" />
+									<rect x="2" y="6" width="2" height="1" />
+									<rect x="2" y="7" width="4" height="1" />
 								</svg>
 								<figcaption>key</figcaption>
 							</figure>
@@ -778,20 +785,21 @@
 									aria-label="diamond pixel avatar"
 								>
 									<rect x="1" y="0" width="6" height="1" />
-									<rect x="0" y="1" width="1" height="1" />
-									<rect x="2" y="1" width="1" height="1" />
+									<rect x="0" y="1" width="2" height="1" />
+									<rect x="3" y="1" width="1" height="1" />
 									<rect x="5" y="1" width="1" height="1" />
 									<rect x="7" y="1" width="1" height="1" />
-									<rect x="0" y="2" width="8" height="1" />
-									<rect x="0" y="3" width="2" height="1" />
-									<rect x="3" y="3" width="2" height="1" />
-									<rect x="6" y="3" width="2" height="1" />
-									<rect x="1" y="4" width="1" height="1" />
-									<rect x="3" y="4" width="2" height="1" />
-									<rect x="6" y="4" width="1" height="1" />
-									<rect x="1" y="5" width="2" height="1" />
-									<rect x="5" y="5" width="2" height="1" />
-									<rect x="2" y="6" width="4" height="1" />
+									<rect x="0" y="2" width="1" height="1" />
+									<rect x="2" y="2" width="1" height="1" />
+									<rect x="4" y="2" width="1" height="1" />
+									<rect x="6" y="2" width="1" height="1" />
+									<rect x="0" y="3" width="8" height="1" />
+									<rect x="0" y="4" width="1" height="1" />
+									<rect x="2" y="4" width="6" height="1" />
+									<rect x="1" y="5" width="1" height="1" />
+									<rect x="3" y="5" width="4" height="1" />
+									<rect x="2" y="6" width="1" height="1" />
+									<rect x="4" y="6" width="2" height="1" />
 									<rect x="3" y="7" width="2" height="1" />
 								</svg>
 								<figcaption>diamond</figcaption>
@@ -829,18 +837,22 @@
 									role="img"
 									aria-label="octopus pixel avatar"
 								>
-									<rect x="2" y="0" width="4" height="1" />
-									<rect x="1" y="1" width="6" height="1" />
-									<rect x="0" y="2" width="3" height="1" />
-									<rect x="5" y="2" width="3" height="1" />
-									<rect x="0" y="3" width="8" height="1" />
-									<rect x="0" y="4" width="8" height="1" />
-									<rect x="0" y="5" width="8" height="1" />
-									<rect x="1" y="6" width="6" height="1" />
-									<rect x="0" y="7" width="1" height="1" />
-									<rect x="2" y="7" width="1" height="1" />
-									<rect x="4" y="7" width="1" height="1" />
-									<rect x="6" y="7" width="1" height="1" />
+									<rect x="1" y="0" width="1" height="1" />
+									<rect x="4" y="0" width="3" height="1" />
+									<rect x="0" y="1" width="1" height="1" />
+									<rect x="3" y="1" width="4" height="1" />
+									<rect x="0" y="2" width="1" height="1" />
+									<rect x="3" y="2" width="1" height="1" />
+									<rect x="5" y="2" width="1" height="1" />
+									<rect x="0" y="3" width="1" height="1" />
+									<rect x="3" y="3" width="3" height="1" />
+									<rect x="1" y="4" width="6" height="1" />
+									<rect x="3" y="5" width="5" height="1" />
+									<rect x="0" y="6" width="2" height="1" />
+									<rect x="3" y="6" width="2" height="1" />
+									<rect x="6" y="6" width="1" height="1" />
+									<rect x="1" y="7" width="3" height="1" />
+									<rect x="6" y="7" width="2" height="1" />
 								</svg>
 								<figcaption>octopus</figcaption>
 							</figure>
@@ -852,20 +864,24 @@
 									role="img"
 									aria-label="penguin pixel avatar"
 								>
-									<rect x="2" y="0" width="4" height="1" />
-									<rect x="1" y="1" width="6" height="1" />
-									<rect x="1" y="2" width="2" height="1" />
-									<rect x="5" y="2" width="2" height="1" />
-									<rect x="1" y="3" width="1" height="1" />
-									<rect x="3" y="3" width="2" height="1" />
-									<rect x="6" y="3" width="1" height="1" />
-									<rect x="0" y="4" width="2" height="1" />
-									<rect x="5" y="4" width="2" height="1" />
-									<rect x="0" y="5" width="2" height="1" />
-									<rect x="5" y="5" width="2" height="1" />
-									<rect x="0" y="6" width="7" height="1" />
-									<rect x="1" y="7" width="1" height="1" />
-									<rect x="6" y="7" width="1" height="1" />
+									<rect class="gray" x="2" y="0" width="4" height="1" />
+									<rect class="gray" x="1" y="1" width="6" height="1" />
+									<rect class="gray" x="1" y="2" width="1" height="1" />
+									<rect class="gray" x="3" y="2" width="2" height="1" />
+									<rect class="gray" x="6" y="2" width="1" height="1" />
+									<rect class="gray" x="1" y="3" width="2" height="1" />
+									<rect class="gray" x="5" y="3" width="2" height="1" />
+									<rect class="gray" x="0" y="4" width="2" height="1" />
+									<rect x="2" y="4" width="2" height="1" />
+									<rect x="5" y="4" width="1" height="1" />
+									<rect class="gray" x="6" y="4" width="2" height="1" />
+									<rect class="gray" x="0" y="5" width="1" height="1" />
+									<rect x="1" y="5" width="6" height="1" />
+									<rect class="gray" x="7" y="5" width="1" height="1" />
+									<rect class="gray" x="0" y="6" width="1" height="1" />
+									<rect x="1" y="6" width="6" height="1" />
+									<rect class="gray" x="7" y="6" width="1" height="1" />
+									<rect x="1" y="7" width="6" height="1" />
 								</svg>
 								<figcaption>penguin</figcaption>
 							</figure>
@@ -957,17 +973,20 @@
 									role="img"
 									aria-label="whale pixel avatar"
 								>
+									<rect x="0" y="0" width="1" height="1" />
+									<rect x="2" y="0" width="1" height="1" />
 									<rect x="4" y="0" width="1" height="1" />
-									<rect x="3" y="1" width="3" height="1" />
-									<rect x="2" y="2" width="4" height="1" />
-									<rect x="7" y="2" width="1" height="1" />
-									<rect x="1" y="3" width="1" height="1" />
-									<rect x="3" y="3" width="4" height="1" />
-									<rect x="0" y="4" width="6" height="1" />
-									<rect x="7" y="4" width="1" height="1" />
-									<rect x="1" y="5" width="5" height="1" />
+									<rect x="1" y="1" width="1" height="1" />
+									<rect x="3" y="1" width="1" height="1" />
+									<rect x="2" y="2" width="1" height="1" />
+									<rect x="2" y="3" width="1" height="1" />
+									<rect x="1" y="4" width="4" height="1" />
+									<rect x="0" y="5" width="6" height="1" />
+									<rect x="7" y="5" width="1" height="1" />
+									<rect x="0" y="6" width="1" height="1" />
 									<rect x="2" y="6" width="4" height="1" />
-									<rect x="3" y="7" width="2" height="1" />
+									<rect x="7" y="6" width="1" height="1" />
+									<rect x="0" y="7" width="8" height="1" />
 								</svg>
 								<figcaption>whale</figcaption>
 							</figure>
@@ -1031,10 +1050,9 @@
 									<rect x="3" y="0" width="2" height="1" />
 									<rect x="2" y="1" width="1" height="1" />
 									<rect x="5" y="1" width="1" height="1" />
-									<rect x="2" y="2" width="1" height="1" />
-									<rect x="5" y="2" width="1" height="1" />
-									<rect x="1" y="3" width="6" height="1" />
-									<rect x="3" y="4" width="2" height="1" />
+									<rect x="1" y="2" width="6" height="1" />
+									<rect x="3" y="3" width="2" height="1" />
+									<rect x="2" y="4" width="4" height="1" />
 									<rect x="0" y="5" width="1" height="1" />
 									<rect x="3" y="5" width="2" height="1" />
 									<rect x="7" y="5" width="1" height="1" />
@@ -1051,18 +1069,24 @@
 									role="img"
 									aria-label="bee pixel avatar"
 								>
-									<rect x="1" y="0" width="1" height="1" />
-									<rect x="6" y="0" width="1" height="1" />
-									<rect x="0" y="1" width="2" height="1" />
-									<rect x="3" y="1" width="2" height="1" />
-									<rect x="6" y="1" width="2" height="1" />
-									<rect x="0" y="2" width="1" height="1" />
-									<rect x="2" y="2" width="4" height="1" />
-									<rect x="7" y="2" width="1" height="1" />
-									<rect x="1" y="3" width="6" height="1" />
-									<rect x="1" y="4" width="6" height="1" />
-									<rect x="1" y="6" width="6" height="1" />
-									<rect x="2" y="7" width="4" height="1" />
+									<rect class="gray" x="3" y="1" width="2" height="1" />
+									<rect x="5" y="1" width="2" height="1" />
+									<rect class="gray" x="2" y="2" width="2" height="1" />
+									<rect x="4" y="2" width="3" height="1" />
+									<rect class="gray" x="3" y="3" width="1" height="1" />
+									<rect x="4" y="3" width="1" height="1" />
+									<rect x="1" y="4" width="5" height="1" />
+									<rect x="0" y="5" width="1" height="1" />
+									<rect class="gray" x="2" y="5" width="1" height="1" />
+									<rect x="3" y="5" width="1" height="1" />
+									<rect class="gray" x="4" y="5" width="1" height="1" />
+									<rect x="5" y="5" width="3" height="1" />
+									<rect x="0" y="6" width="2" height="1" />
+									<rect class="gray" x="2" y="6" width="1" height="1" />
+									<rect x="3" y="6" width="1" height="1" />
+									<rect class="gray" x="4" y="6" width="1" height="1" />
+									<rect x="5" y="6" width="2" height="1" />
+									<rect x="1" y="7" width="5" height="1" />
 								</svg>
 								<figcaption>bee</figcaption>
 							</figure>
@@ -1097,21 +1121,22 @@
 									role="img"
 									aria-label="owl pixel avatar"
 								>
-									<rect x="0" y="0" width="1" height="1" />
-									<rect x="7" y="0" width="1" height="1" />
-									<rect x="0" y="1" width="2" height="1" />
-									<rect x="6" y="1" width="2" height="1" />
-									<rect x="1" y="2" width="6" height="1" />
-									<rect x="1" y="3" width="1" height="1" />
+									<rect x="1" y="0" width="1" height="1" />
+									<rect x="6" y="0" width="1" height="1" />
+									<rect x="0" y="1" width="1" height="1" />
+									<rect x="7" y="1" width="1" height="1" />
+									<rect x="0" y="2" width="8" height="1" />
+									<rect x="0" y="3" width="1" height="1" />
 									<rect x="3" y="3" width="2" height="1" />
-									<rect x="6" y="3" width="1" height="1" />
-									<rect x="1" y="4" width="1" height="1" />
+									<rect x="7" y="3" width="1" height="1" />
+									<rect x="0" y="4" width="1" height="1" />
 									<rect x="3" y="4" width="2" height="1" />
-									<rect x="6" y="4" width="1" height="1" />
-									<rect x="1" y="5" width="6" height="1" />
-									<rect x="1" y="6" width="6" height="1" />
-									<rect x="2" y="7" width="1" height="1" />
-									<rect x="5" y="7" width="1" height="1" />
+									<rect x="7" y="4" width="1" height="1" />
+									<rect x="0" y="5" width="8" height="1" />
+									<rect x="0" y="6" width="3" height="1" />
+									<rect x="5" y="6" width="3" height="1" />
+									<rect x="1" y="7" width="3" height="1" />
+									<rect x="5" y="7" width="2" height="1" />
 								</svg>
 								<figcaption>owl</figcaption>
 							</figure>
@@ -1123,17 +1148,19 @@
 									role="img"
 									aria-label="fox pixel avatar"
 								>
-									<rect x="0" y="0" width="2" height="1" />
-									<rect x="6" y="0" width="2" height="1" />
+									<rect x="0" y="0" width="1" height="1" />
+									<rect class="gray" x="4" y="0" width="1" height="1" />
 									<rect x="0" y="1" width="2" height="1" />
-									<rect x="6" y="1" width="2" height="1" />
-									<rect x="0" y="2" width="8" height="1" />
-									<rect x="0" y="3" width="3" height="1" />
-									<rect x="5" y="3" width="3" height="1" />
-									<rect x="0" y="4" width="8" height="1" />
-									<rect x="0" y="5" width="8" height="1" />
-									<rect x="1" y="6" width="6" height="1" />
-									<rect x="2" y="7" width="4" height="1" />
+									<rect class="gray" x="3" y="1" width="2" height="1" />
+									<rect x="0" y="2" width="3" height="1" />
+									<rect class="gray" x="3" y="2" width="2" height="1" />
+									<rect x="0" y="3" width="5" height="1" />
+									<rect x="7" y="3" width="1" height="1" />
+									<rect x="0" y="4" width="2" height="1" />
+									<rect x="3" y="4" width="5" height="1" />
+									<rect x="0" y="5" width="7" height="1" />
+									<rect x="0" y="6" width="6" height="1" />
+									<rect x="0" y="7" width="5" height="1" />
 								</svg>
 								<figcaption>fox</figcaption>
 							</figure>
@@ -1145,18 +1172,19 @@
 									role="img"
 									aria-label="robot pixel avatar"
 								>
-									<rect x="3" y="0" width="2" height="1" />
-									<rect x="3" y="1" width="1" height="1" />
-									<rect x="1" y="2" width="6" height="1" />
-									<rect x="0" y="3" width="1" height="1" />
-									<rect x="2" y="3" width="4" height="1" />
-									<rect x="7" y="3" width="1" height="1" />
+									<rect x="1" y="0" width="6" height="1" />
+									<rect x="3" y="1" width="2" height="1" />
+									<rect x="0" y="2" width="8" height="1" />
+									<rect x="0" y="3" width="8" height="1" />
 									<rect x="0" y="4" width="1" height="1" />
-									<rect x="3" y="4" width="2" height="1" />
+									<rect x="2" y="4" width="4" height="1" />
 									<rect x="7" y="4" width="1" height="1" />
-									<rect x="1" y="5" width="6" height="1" />
-									<rect x="1" y="6" width="5" height="1" />
-									<rect x="1" y="7" width="6" height="1" />
+									<rect x="0" y="5" width="1" height="1" />
+									<rect x="2" y="5" width="4" height="1" />
+									<rect x="7" y="5" width="1" height="1" />
+									<rect x="0" y="6" width="3" height="1" />
+									<rect x="5" y="6" width="3" height="1" />
+									<rect x="0" y="7" width="8" height="1" />
 								</svg>
 								<figcaption>robot</figcaption>
 							</figure>
@@ -1171,10 +1199,10 @@
 									<rect x="0" y="0" width="1" height="1" />
 									<rect x="7" y="0" width="1" height="1" />
 									<rect x="0" y="1" width="1" height="1" />
-									<rect x="3" y="1" width="2" height="1" />
+									<rect x="3" y="1" width="1" height="1" />
 									<rect x="7" y="1" width="1" height="1" />
 									<rect x="0" y="2" width="2" height="1" />
-									<rect x="3" y="2" width="2" height="1" />
+									<rect x="3" y="2" width="1" height="1" />
 									<rect x="6" y="2" width="2" height="1" />
 									<rect x="0" y="3" width="2" height="1" />
 									<rect x="3" y="3" width="2" height="1" />
@@ -1202,13 +1230,11 @@
 									<rect x="4" y="1" width="2" height="1" />
 									<rect x="0" y="2" width="2" height="1" />
 									<rect x="4" y="2" width="2" height="1" />
-									<rect x="0" y="3" width="2" height="1" />
-									<rect x="4" y="3" width="2" height="1" />
-									<rect x="1" y="4" width="4" height="1" />
-									<rect x="2" y="5" width="2" height="1" />
-									<rect x="2" y="6" width="4" height="1" />
-									<rect x="2" y="7" width="2" height="1" />
-									<rect x="5" y="7" width="2" height="1" />
+									<rect x="1" y="3" width="4" height="1" />
+									<rect x="2" y="4" width="2" height="1" />
+									<rect x="2" y="5" width="4" height="1" />
+									<rect x="2" y="6" width="2" height="1" />
+									<rect x="2" y="7" width="4" height="1" />
 								</svg>
 								<figcaption>key</figcaption>
 							</figure>
@@ -1221,20 +1247,21 @@
 									aria-label="diamond pixel avatar"
 								>
 									<rect x="1" y="0" width="6" height="1" />
-									<rect x="0" y="1" width="1" height="1" />
-									<rect x="2" y="1" width="1" height="1" />
+									<rect x="0" y="1" width="2" height="1" />
+									<rect x="3" y="1" width="1" height="1" />
 									<rect x="5" y="1" width="1" height="1" />
 									<rect x="7" y="1" width="1" height="1" />
-									<rect x="0" y="2" width="8" height="1" />
-									<rect x="0" y="3" width="2" height="1" />
-									<rect x="3" y="3" width="2" height="1" />
-									<rect x="6" y="3" width="2" height="1" />
-									<rect x="1" y="4" width="1" height="1" />
-									<rect x="3" y="4" width="2" height="1" />
-									<rect x="6" y="4" width="1" height="1" />
-									<rect x="1" y="5" width="2" height="1" />
-									<rect x="5" y="5" width="2" height="1" />
-									<rect x="2" y="6" width="4" height="1" />
+									<rect x="0" y="2" width="1" height="1" />
+									<rect x="2" y="2" width="1" height="1" />
+									<rect x="4" y="2" width="1" height="1" />
+									<rect x="6" y="2" width="1" height="1" />
+									<rect x="0" y="3" width="8" height="1" />
+									<rect x="0" y="4" width="1" height="1" />
+									<rect x="2" y="4" width="6" height="1" />
+									<rect x="1" y="5" width="1" height="1" />
+									<rect x="3" y="5" width="4" height="1" />
+									<rect x="2" y="6" width="1" height="1" />
+									<rect x="4" y="6" width="2" height="1" />
 									<rect x="3" y="7" width="2" height="1" />
 								</svg>
 								<figcaption>diamond</figcaption>
@@ -1272,18 +1299,22 @@
 									role="img"
 									aria-label="octopus pixel avatar"
 								>
-									<rect x="2" y="0" width="4" height="1" />
-									<rect x="1" y="1" width="6" height="1" />
-									<rect x="0" y="2" width="3" height="1" />
-									<rect x="5" y="2" width="3" height="1" />
-									<rect x="0" y="3" width="8" height="1" />
-									<rect x="0" y="4" width="8" height="1" />
-									<rect x="0" y="5" width="8" height="1" />
-									<rect x="1" y="6" width="6" height="1" />
-									<rect x="0" y="7" width="1" height="1" />
-									<rect x="2" y="7" width="1" height="1" />
-									<rect x="4" y="7" width="1" height="1" />
-									<rect x="6" y="7" width="1" height="1" />
+									<rect x="1" y="0" width="1" height="1" />
+									<rect x="4" y="0" width="3" height="1" />
+									<rect x="0" y="1" width="1" height="1" />
+									<rect x="3" y="1" width="4" height="1" />
+									<rect x="0" y="2" width="1" height="1" />
+									<rect x="3" y="2" width="1" height="1" />
+									<rect x="5" y="2" width="1" height="1" />
+									<rect x="0" y="3" width="1" height="1" />
+									<rect x="3" y="3" width="3" height="1" />
+									<rect x="1" y="4" width="6" height="1" />
+									<rect x="3" y="5" width="5" height="1" />
+									<rect x="0" y="6" width="2" height="1" />
+									<rect x="3" y="6" width="2" height="1" />
+									<rect x="6" y="6" width="1" height="1" />
+									<rect x="1" y="7" width="3" height="1" />
+									<rect x="6" y="7" width="2" height="1" />
 								</svg>
 								<figcaption>octopus</figcaption>
 							</figure>
@@ -1295,20 +1326,24 @@
 									role="img"
 									aria-label="penguin pixel avatar"
 								>
-									<rect x="2" y="0" width="4" height="1" />
-									<rect x="1" y="1" width="6" height="1" />
-									<rect x="1" y="2" width="2" height="1" />
-									<rect x="5" y="2" width="2" height="1" />
-									<rect x="1" y="3" width="1" height="1" />
-									<rect x="3" y="3" width="2" height="1" />
-									<rect x="6" y="3" width="1" height="1" />
-									<rect x="0" y="4" width="2" height="1" />
-									<rect x="5" y="4" width="2" height="1" />
-									<rect x="0" y="5" width="2" height="1" />
-									<rect x="5" y="5" width="2" height="1" />
-									<rect x="0" y="6" width="7" height="1" />
-									<rect x="1" y="7" width="1" height="1" />
-									<rect x="6" y="7" width="1" height="1" />
+									<rect class="gray" x="2" y="0" width="4" height="1" />
+									<rect class="gray" x="1" y="1" width="6" height="1" />
+									<rect class="gray" x="1" y="2" width="1" height="1" />
+									<rect class="gray" x="3" y="2" width="2" height="1" />
+									<rect class="gray" x="6" y="2" width="1" height="1" />
+									<rect class="gray" x="1" y="3" width="2" height="1" />
+									<rect class="gray" x="5" y="3" width="2" height="1" />
+									<rect class="gray" x="0" y="4" width="2" height="1" />
+									<rect x="2" y="4" width="2" height="1" />
+									<rect x="5" y="4" width="1" height="1" />
+									<rect class="gray" x="6" y="4" width="2" height="1" />
+									<rect class="gray" x="0" y="5" width="1" height="1" />
+									<rect x="1" y="5" width="6" height="1" />
+									<rect class="gray" x="7" y="5" width="1" height="1" />
+									<rect class="gray" x="0" y="6" width="1" height="1" />
+									<rect x="1" y="6" width="6" height="1" />
+									<rect class="gray" x="7" y="6" width="1" height="1" />
+									<rect x="1" y="7" width="6" height="1" />
 								</svg>
 								<figcaption>penguin</figcaption>
 							</figure>
@@ -1400,17 +1435,20 @@
 									role="img"
 									aria-label="whale pixel avatar"
 								>
+									<rect x="0" y="0" width="1" height="1" />
+									<rect x="2" y="0" width="1" height="1" />
 									<rect x="4" y="0" width="1" height="1" />
-									<rect x="3" y="1" width="3" height="1" />
-									<rect x="2" y="2" width="4" height="1" />
-									<rect x="7" y="2" width="1" height="1" />
-									<rect x="1" y="3" width="1" height="1" />
-									<rect x="3" y="3" width="4" height="1" />
-									<rect x="0" y="4" width="6" height="1" />
-									<rect x="7" y="4" width="1" height="1" />
-									<rect x="1" y="5" width="5" height="1" />
+									<rect x="1" y="1" width="1" height="1" />
+									<rect x="3" y="1" width="1" height="1" />
+									<rect x="2" y="2" width="1" height="1" />
+									<rect x="2" y="3" width="1" height="1" />
+									<rect x="1" y="4" width="4" height="1" />
+									<rect x="0" y="5" width="6" height="1" />
+									<rect x="7" y="5" width="1" height="1" />
+									<rect x="0" y="6" width="1" height="1" />
 									<rect x="2" y="6" width="4" height="1" />
-									<rect x="3" y="7" width="2" height="1" />
+									<rect x="7" y="6" width="1" height="1" />
+									<rect x="0" y="7" width="8" height="1" />
 								</svg>
 								<figcaption>whale</figcaption>
 							</figure>

--- a/marketing/styles.css
+++ b/marketing/styles.css
@@ -761,6 +761,10 @@ section {
 	height: 36px;
 	fill: var(--ink);
 }
+/* Half-lit (`+`) LED cells read as a fainter ink, matching the in-app sprite. */
+.avatar-tile .sprite .gray {
+	fill-opacity: 0.42;
+}
 .avatar-tile figcaption {
 	font-size: 10px;
 	text-transform: uppercase;


### PR DESCRIPTION
## What

The marketing site's avatar carousel was showing hand-written SVGs that had drifted from the actual sprite definitions in `src/avatars/`. Several sprites had been redrawn since the markup was last touched — `anchor`, `bee`, `fox`, and `penguin` among them (bee/fox/penguin now use half-lit `+` cells the old flat markup couldn't represent).

## Changes

- **`marketing/index.html`** — regenerated all 18 carousel tiles (both marquee copies) directly from the live `avatars[]` registry, run-length-encoding each sprite's `#`/`+` cells into `<rect>`s. Verified programmatically that every tile reconstructs its source sprite exactly (18/18, 0 mismatches).
- **`marketing/styles.css`** — added `.avatar-tile .sprite .gray { fill-opacity: 0.42; }` so half-lit (`+`) cells render fainter, matching the in-app `Avatar.svelte` look.

The curated set and order are unchanged (anchor, bee, rocket, owl, fox, robot, crown, key, diamond, ghost, octopus, penguin, snakegame, svelte, target, whale, invader, kangaroo) — only the pixel data was refreshed.

## Note

These remain static hand-embedded SVGs, so they can drift again if the sprites are edited. Happy to follow up with a committed generator script if that's wanted.